### PR TITLE
Make dyn error types Send + Sync + 'static

### DIFF
--- a/client/src/handle.rs
+++ b/client/src/handle.rs
@@ -23,7 +23,7 @@ pub enum Error {
     Disconnected,
     /// The command returned an error.
     #[error("command failed")]
-    Command(Box<dyn std::error::Error>),
+    Command(Box<dyn std::error::Error + Send + Sync + 'static>),
     /// The operation timed out.
     #[error("the operation timed out")]
     Timeout,

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -22,7 +22,7 @@ pub enum Error {
 
     /// A channel send or receive error.
     #[error("channel error: {0}")]
-    Channel(Box<dyn std::error::Error + Send + Sync>),
+    Channel(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 impl<T: Debug + Send + Sync + 'static> From<crossbeam::SendError<T>> for Error {


### PR DESCRIPTION
In order for errors to be used downstream it helps if they can be sent
between threads i.e., `Send + Sync + 'static`.

Add type constraints to the two error variants that use `dyn Error`.

P.S loving this library, thanks for your work!