### PR TITLE
Persistent peers

### DIFF
--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -651,6 +651,8 @@ impl<T: BlockTree, F: Filters, P: peer::Store> Protocol<T, F, P> {
                 domains: domains.clone(),
                 target_outbound_peers,
                 max_inbound_peers,
+                retry_max_wait: LocalDuration::from_mins(60),
+                retry_min_wait: LocalDuration::from_secs(1),
                 required_services,
                 preferred_services: syncmgr::REQUIRED_SERVICES | cbfmgr::REQUIRED_SERVICES,
                 services,

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -647,7 +647,7 @@ impl<T: BlockTree, F: Filters, P: peer::Store> Protocol<T, F, P> {
             peermgr::Config {
                 protocol_version: PROTOCOL_VERSION,
                 whitelist,
-                retry: connect,
+                persistent: connect,
                 domains: domains.clone(),
                 target_outbound_peers,
                 max_inbound_peers,

--- a/p2p/src/protocol/peermgr.rs
+++ b/p2p/src/protocol/peermgr.rs
@@ -292,6 +292,7 @@ impl<U: Handshake + SetTimeout + Connect + Disconnect + Events> PeerManager<U> {
         let delay = LocalDuration::from_secs(2_u64.pow((*attempts).max(63)))
             .clamp(self.config.retry_min_wait, self.config.retry_max_wait);
         self.retry_at.insert(*addr, local_time + delay);
+        self.upstream.set_timeout(delay);
         *attempts = *attempts + 1;
     }
 

--- a/p2p/src/protocol/peermgr.rs
+++ b/p2p/src/protocol/peermgr.rs
@@ -296,6 +296,7 @@ impl<U: Handshake + SetTimeout + Connect + Disconnect + Events> PeerManager<U> {
     }
 
     fn backoff_remove_peer(&mut self, addr: &net::SocketAddr) {
+        debug_assert!(self.is_connected(addr));
         self.backoff_delay.remove(addr);
         self.backoff_next_try.remove(addr);
     }

--- a/p2p/src/protocol/peermgr.rs
+++ b/p2p/src/protocol/peermgr.rs
@@ -293,7 +293,7 @@ impl<U: Handshake + SetTimeout + Connect + Disconnect + Events> PeerManager<U> {
             .clamp(self.config.retry_min_wait, self.config.retry_max_wait);
         self.retry_at.insert(*addr, local_time + delay);
         self.upstream.set_timeout(delay);
-        *attempts = *attempts + 1;
+        *attempts += 1;
     }
 
     fn retrier_remove_peer(&mut self, addr: &net::SocketAddr) {

--- a/p2p/src/protocol/peermgr.rs
+++ b/p2p/src/protocol/peermgr.rs
@@ -383,13 +383,14 @@ impl<U: Handshake + SetTimeout + Connect + Disconnect + Events> PeerManager<U> {
         debug_assert!(!self.is_disconnected(addr));
 
         self.peers.remove(addr);
-        // If an outbound peer disconnected, we should make sure to maintain
-        // our target outbound connection count.
-        self.maintain_connections(addrs, local_time);
 
         if self.config.persistent.contains(addr) {
             log::error!("persistent peer disconnected: {}", addr);
             self.backoff_retry_later(&addr, local_time);
+        } else {
+            // If an outbound peer disconnected, we should make sure to maintain
+            // our target outbound connection count.
+            self.maintain_connections(addrs, local_time);
         }
 
         Events::event(&self.upstream, Event::Disconnected(*addr));

--- a/p2p/src/protocol/peermgr.rs
+++ b/p2p/src/protocol/peermgr.rs
@@ -280,7 +280,11 @@ impl<U: Handshake + SetTimeout + Connect + Disconnect + Events> PeerManager<U> {
 
         for addr in peers {
             if !self.connect(&addr, time) {
-                panic!("{}: unable to connect to persistent peer: {}", source!(), addr);
+                panic!(
+                    "{}: unable to connect to persistent peer: {}",
+                    source!(),
+                    addr
+                );
             }
         }
         self.upstream.set_timeout(IDLE_TIMEOUT);

--- a/p2p/src/protocol/peermgr.rs
+++ b/p2p/src/protocol/peermgr.rs
@@ -14,7 +14,6 @@
 //!   3. Send `verack` message.
 //!   4. Expect `verack` message from remote.
 //!
-use std::cmp;
 use std::net;
 
 use bitcoin::network::address::Address;
@@ -27,6 +26,7 @@ use nakamoto_common::p2p::Domain;
 use nakamoto_common::block::time::{LocalDuration, LocalTime};
 use nakamoto_common::block::Height;
 use nakamoto_common::collections::{HashMap, HashSet};
+use nakamoto_common::source;
 
 use crate::protocol::addrmgr;
 
@@ -280,7 +280,7 @@ impl<U: Handshake + SetTimeout + Connect + Disconnect + Events> PeerManager<U> {
 
         for addr in peers {
             if !self.connect(&addr, time) {
-                log::error!("unable to connect to persistent peer: {}", addr);
+                panic!("{}: unable to connect to persistent peer: {}", source!(), addr);
             }
         }
         self.upstream.set_timeout(IDLE_TIMEOUT);
@@ -309,7 +309,7 @@ impl<U: Handshake + SetTimeout + Connect + Disconnect + Events> PeerManager<U> {
             .map(|(k, _)| *k)
             .collect();
         for peer in peers {
-            self.connect(&peer, local_time);
+            debug_assert!(self.connect(&peer, local_time));
             self.backoff_next_try.remove(&peer);
         }
     }


### PR DESCRIPTION
Try persisting connections with user specified peers using exponential backoff.  The peers are defined via configuration or command line via the 'connect' parameter.

Issue #8 