### PR TITLE
Refactor protocol type

### DIFF
--- a/client/src/handle.rs
+++ b/client/src/handle.rs
@@ -14,7 +14,6 @@ use nakamoto_common::bitcoin::network::message::NetworkMessage;
 use nakamoto_common::block::filter::BlockFilter;
 use nakamoto_common::block::tree::{BlockReader, ImportResult};
 use nakamoto_common::block::{self, Block, BlockHash, BlockHeader, Height, Transaction};
-use nakamoto_common::network::Network;
 use nakamoto_common::nonempty::NonEmpty;
 use nakamoto_p2p::protocol::Link;
 use nakamoto_p2p::protocol::{self, Command, CommandError, GetFiltersError, Peer};
@@ -64,8 +63,6 @@ impl<T> From<chan::SendError<T>> for Error {
 
 /// A handle for communicating with a node process.
 pub trait Handle: Sized + Send + Sync + Clone {
-    /// Get the Bitcoin network the client is configured for.
-    fn network(&self) -> Network;
     /// Get the tip of the chain.
     fn get_tip(&self) -> Result<(Height, BlockHeader), Error>;
     /// Get a full block from the network.

--- a/client/src/tests.rs
+++ b/client/src/tests.rs
@@ -37,9 +37,9 @@ fn network(
     let mut handles = Vec::new();
 
     for cfg in cfgs.iter().cloned() {
-        let checkpoints = cfg.network.checkpoints().collect::<Vec<_>>();
-        let genesis = cfg.network.genesis();
-        let params = cfg.network.params();
+        let checkpoints = cfg.protocol.network.checkpoints().collect::<Vec<_>>();
+        let genesis = cfg.protocol.network.genesis();
+        let params = cfg.protocol.network.params();
 
         let node = Client::new()?;
         let handle = node.handle();
@@ -57,11 +57,10 @@ fn network(
                 let local_time = time::SystemTime::now().into();
                 let clock = AdjustedTime::<net::SocketAddr>::new(local_time);
                 let rng = fastrand::Rng::new();
-                let cfg = cfg.into();
 
                 node.run_with(
                     vec![([0, 0, 0, 0], 0).into()],
-                    Protocol::new(cache, filters, peers, clock, rng, cfg),
+                    Protocol::new(cache, filters, peers, clock, rng, cfg.protocol),
                 )
                 .unwrap();
             }
@@ -96,7 +95,10 @@ fn test_full_sync() {
     fn config(name: &'static str) -> Config {
         Config {
             name,
-            services: syncmgr::REQUIRED_SERVICES,
+            protocol: protocol::Config {
+                services: syncmgr::REQUIRED_SERVICES,
+                ..protocol::Config::default()
+            },
             ..Config::default()
         }
     }
@@ -132,7 +134,10 @@ fn test_wait_for_peers() {
 
     let cfgs = vec![
         Config {
-            services: ServiceFlags::NETWORK,
+            protocol: protocol::Config {
+                services: ServiceFlags::NETWORK,
+                ..protocol::Config::default()
+            },
             ..Default::default()
         };
         5

--- a/client/src/tests/mock.rs
+++ b/client/src/tests/mock.rs
@@ -68,12 +68,8 @@ impl Client {
         }
     }
 
-    pub fn step(&mut self, input: protocol::Input, local_time: LocalTime) -> Vec<protocol::Out> {
-        use nakamoto_p2p::traits::Protocol as _;
-
+    pub fn step(&mut self) -> Vec<protocol::Out> {
         let mut outputs = Vec::new();
-
-        self.protocol.step(input, local_time);
 
         for out in self.outputs.try_iter() {
             match out {
@@ -255,6 +251,6 @@ impl Handle for TestHandle {
     }
 
     fn shutdown(self) -> Result<(), handle::Error> {
-        self.command(Command::Shutdown)
+        Ok(())
     }
 }

--- a/net/poll/src/socket.rs
+++ b/net/poll/src/socket.rs
@@ -10,7 +10,7 @@ use nakamoto_common::bitcoin::network::stream_reader::StreamReader;
 
 use log::*;
 
-use nakamoto_p2p::protocol::{Input, Link};
+use nakamoto_p2p::protocol::Link;
 
 use crate::fallible;
 
@@ -93,15 +93,11 @@ impl<R: Read + Write, M: Encodable + Decodable + Debug> Socket<R, M> {
         }
     }
 
-    pub fn drain(
-        &mut self,
-        inputs: &mut VecDeque<Input>,
-        source: &mut popol::Source,
-    ) -> Result<(), io::Error> {
+    pub fn drain(&mut self, source: &mut popol::Source) -> Result<(), io::Error> {
         while let Some(msg) = self.queue.pop_front() {
             match self.write(&msg) {
-                Ok(n) => {
-                    inputs.push_back(Input::Sent(self.address, n));
+                Ok(_n) => {
+                    // TODO: Keep count of bytes written.
                 }
                 Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
                     source.set(popol::interest::WRITE);

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -3,7 +3,6 @@
 
 use std::net;
 use std::path::PathBuf;
-use std::time;
 
 pub use nakamoto_client::client::{self, Client, Config, Network};
 pub use nakamoto_client::error::Error;
@@ -32,7 +31,6 @@ pub fn run(
         },
         connect: connect.to_vec(),
         domains: domains.to_vec(),
-        timeout: time::Duration::from_secs(30),
         ..Config::default()
     };
     if let Some(path) = root {
@@ -42,5 +40,5 @@ pub fn run(
         cfg.target_outbound_peers = connect.len();
     }
 
-    Client::<Reactor>::new(cfg)?.run()
+    Client::<Reactor>::new()?.run(cfg)
 }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,6 +8,8 @@ pub use nakamoto_client::client::{self, Client, Config, Network};
 pub use nakamoto_client::error::Error;
 pub use nakamoto_client::Domain;
 
+use nakamoto_client::protocol;
+
 pub mod logger;
 
 /// The network reactor we're going to use.
@@ -23,21 +25,24 @@ pub fn run(
     network: Network,
 ) -> Result<(), Error> {
     let mut cfg = Config {
-        network,
+        protocol: protocol::Config {
+            connect: connect.to_vec(),
+            domains: domains.to_vec(),
+            network,
+            ..protocol::Config::default()
+        },
         listen: if listen.is_empty() {
             vec![([0, 0, 0, 0], 0).into()]
         } else {
             listen.to_vec()
         },
-        connect: connect.to_vec(),
-        domains: domains.to_vec(),
         ..Config::default()
     };
     if let Some(path) = root {
         cfg.root = path;
     }
     if !connect.is_empty() {
-        cfg.target_outbound_peers = connect.len();
+        cfg.protocol.target_outbound_peers = connect.len();
     }
 
     Client::<Reactor>::new()?.run(cfg)

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -475,8 +475,8 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            network: network::Network::Mainnet,
-            params: Params::new(network::Network::Mainnet.into()),
+            network: network::Network::default(),
+            params: Params::new(network::Network::default().into()),
             connect: Vec::new(),
             domains: Domain::all(),
             services: ServiceFlags::NONE,

--- a/p2p/src/protocol/addrmgr.rs
+++ b/p2p/src/protocol/addrmgr.rs
@@ -778,7 +778,6 @@ mod tests {
     use std::collections::HashMap;
     use std::iter;
 
-    use crossbeam_channel as chan;
     use nakamoto_common::network::Network;
     use quickcheck::TestResult;
     use quickcheck_macros::quickcheck;
@@ -976,11 +975,9 @@ mod tests {
         if size > 24 {
             return TestResult::discard();
         }
-        let (sender, _receiver) = chan::unbounded();
 
         let mut addrmgr = {
-            let upstream =
-                crate::protocol::channel::Channel::new(Network::Mainnet, 0, "test", sender);
+            let upstream = crate::protocol::channel::Channel::new(Network::Mainnet, 0, "test");
 
             AddressManager::new(
                 Config::default(),

--- a/p2p/src/protocol/tests/simulator.rs
+++ b/p2p/src/protocol/tests/simulator.rs
@@ -282,8 +282,8 @@ impl Simulation {
         }
 
         // Schedule any messages in the pipes.
-        for peer in nodes.values() {
-            for o in peer.upstream.try_iter() {
+        for peer in nodes.values_mut() {
+            for o in peer.upstream.drain() {
                 self.schedule(&peer.addr.ip(), o);
             }
         }
@@ -332,7 +332,7 @@ impl Simulation {
                             Input::Tock => p.protocol.tock(self.time),
                             Input::Received(addr, msg) => p.protocol.received(&addr, msg),
                         }
-                        for o in p.upstream.try_iter() {
+                        for o in p.upstream.drain() {
                             self.schedule(&node, o);
                         }
                     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,11 +27,11 @@
 //!         ..Config::default()
 //!     };
 //!     // Create a client using the above network reactor.
-//!     let client = Client::<Reactor>::new(cfg)?;
+//!     let client = Client::<Reactor>::new()?;
 //!     let handle = client.handle();
 //!
 //!     // Run the client on a different thread, to not block the main thread.
-//!     thread::spawn(|| client.run().unwrap());
+//!     thread::spawn(|| client.run(cfg).unwrap());
 //!
 //!     // Wait for the client to be connected to a peer.
 //!     handle.wait_for_peers(1, Services::default())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,10 +22,8 @@
 //!
 //! /// Run the light-client.
 //! fn main() -> Result<(), Error> {
-//!     let cfg = Config {
-//!         network: Network::Testnet,
-//!         ..Config::default()
-//!     };
+//!     let cfg = Config::new(Network::Testnet);
+//!
 //!     // Create a client using the above network reactor.
 //!     let client = Client::<Reactor>::new()?;
 //!     let handle = client.handle();

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -106,7 +106,7 @@ pub fn run(addresses: Vec<Address>, birth: Height) -> Result<(), Error> {
     };
 
     // Create a new client using `Reactor` for networking.
-    let client = Client::<Reactor>::new(cfg)?;
+    let client = Client::<Reactor>::new()?;
     let handle = client.handle();
 
     // Create a new wallet and rescan the chain from the provided `birth` height for
@@ -114,7 +114,7 @@ pub fn run(addresses: Vec<Address>, birth: Height) -> Result<(), Error> {
     let mut wallet = Wallet::new(handle.clone(), addresses);
 
     // Start the network client in the background.
-    thread::spawn(|| client.run().unwrap());
+    thread::spawn(|| client.run(cfg).unwrap());
 
     wallet.rescan(birth)?;
 

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -11,7 +11,7 @@ use nakamoto_common::bitcoin::Address;
 use nakamoto_client::handle::{self, Handle};
 use nakamoto_client::spv::utxos::Utxos;
 use nakamoto_client::Network;
-use nakamoto_client::{client, Client, Config, Event};
+use nakamoto_client::{client, protocol, Client, Config, Event};
 use nakamoto_common::block::Height;
 use nakamoto_common::network::Services;
 
@@ -101,7 +101,10 @@ type Reactor = nakamoto_net_poll::Reactor<net::TcpStream, client::Publisher>;
 pub fn run(addresses: Vec<Address>, birth: Height) -> Result<(), Error> {
     let cfg = Config {
         listen: vec![], // Don't listen for incoming connections.
-        network: Network::Mainnet,
+        protocol: protocol::Config {
+            network: Network::Mainnet,
+            ..protocol::Config::default()
+        },
         ..Config::default()
     };
 


### PR DESCRIPTION
The 'Input' type is now only used in tests. General cleanup
of unused functionality.