### PR TITLE
Fix filter rollback behavior

### DIFF
--- a/chain/src/filter/cache.rs
+++ b/chain/src/filter/cache.rs
@@ -136,10 +136,7 @@ impl<S: Store<Header = StoredHeader>> Filters for FilterCache<S> {
         self.headers.tail.len() as Height
     }
 
-    fn rollback(&mut self, n: usize) -> Result<(), Error> {
-        // Height to rollback to.
-        let height = self.height() - n as Height;
-
+    fn rollback(&mut self, height: Height) -> Result<(), Error> {
         self.header_store.rollback(height)?;
         self.headers.tail.truncate(height as usize);
 

--- a/common/src/block/filter.rs
+++ b/common/src/block/filter.rs
@@ -69,8 +69,8 @@ pub trait Filters {
             self.get_header(height - 1).map(|(_, h)| h)
         }
     }
-    /// Rollback chain by the given number of headers.
-    fn rollback(&mut self, n: usize) -> Result<(), Error>;
+    /// Rollback filter chain to the given height.
+    fn rollback(&mut self, height: Height) -> Result<(), Error>;
     /// Truncate the filter header chain to zero.
     fn clear(&mut self) -> Result<(), Error>;
 }

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -599,21 +599,26 @@ impl<T: BlockTree, F: Filters, P: peer::Store> Protocol<T, F, P> {
                     .received_headers(&addr, headers, &self.clock, &mut self.tree)
                 {
                     Err(e) => log::error!("Error receiving headers: {}", e),
-                    Ok(ImportResult::TipChanged(_, _, _, reverted, _)) if !reverted.is_empty() => {
-                        // By rolling back the filter headers, we will trigger
-                        // a re-download of the missing headers, which should result
-                        // in us having the new headers.
-                        self.cbfmgr.rollback(reverted.len()).unwrap();
+                    Ok(ImportResult::TipChanged(_, _, _, reverted, _)) => {
+                        // Nb. the reverted blocks are ordered from the tip down to
+                        // the oldest ancestor.
+                        if let Some((height, _)) = reverted.last() {
+                            // The height we need to rollback to, ie. the tip of our new chain
+                            // and the tallest block we are keeping.
+                            let fork_height = height - 1;
+                            self.cbfmgr.rollback(fork_height).unwrap();
 
-                        for (height, _) in reverted {
-                            for tx in self.invmgr.block_reverted(height) {
-                                self.cbfmgr.watch_transaction(&tx);
+                            for (height, _) in reverted {
+                                for tx in self.invmgr.block_reverted(height) {
+                                    self.cbfmgr.watch_transaction(&tx);
+                                }
                             }
                         }
-                    }
-                    Ok(ImportResult::TipChanged { .. }) => {
                         // Trigger a filter sync, since we're going to have to catch up on the
                         // new block header(s). This is not required, but reduces latency.
+                        //
+                        // In the case of a re-org, this will trigger a re-download of the
+                        // missing headers after the rollback.
                         self.cbfmgr.sync(&self.tree, now);
                     }
                     _ => {}

--- a/test/src/block/cache/model.rs
+++ b/test/src/block/cache/model.rs
@@ -290,10 +290,7 @@ impl Filters for FilterCache {
         self.headers.tail.len() as Height
     }
 
-    fn rollback(&mut self, n: usize) -> Result<(), filter::Error> {
-        // Height to rollback to.
-        let height = self.height() - n as Height;
-
+    fn rollback(&mut self, height: Height) -> Result<(), filter::Error> {
         self.headers.tail.truncate(height as usize);
 
         let heights = self


### PR DESCRIPTION
Instead of reverting a number of headers, we rollback to a specific
height. The issue we fix is that in cases where the filter header chain
is not caught up with the block header chain, this would cause a
re-download of perfectly valid filters.