### PR TITLE
Compact Filters: test catching when behind Block Headers

### DIFF
--- a/p2p/src/protocol/cbfmgr.rs
+++ b/p2p/src/protocol/cbfmgr.rs
@@ -1495,26 +1495,25 @@ mod tests {
             &tree,
         );
 
+        let tip = chain.last();
         let mut events = util::events(cbfmgr.upstream.drain());
-        let ev = events.find(|e| {
-            matches!(e, Event::Syncing{start_height, stop_hash, ..}
+        events
+            .find(|e| {
+                matches!(e, Event::Syncing { start_height, stop_hash, .. }
                                if (*start_height as usize) == (cfheader_height + 1)
-                               && stop_hash == &chain.last().block_hash())
-        });
-        assert_matches!(ev, Some(..), "expect syncing event emitted");
+                               && stop_hash == &tip.block_hash())
+            })
+            .expect("syncing event emitted");
 
         let mut msgs = output::test::messages(&mut cbfmgr.upstream, &remote);
-        let msg = msgs.find(|m| {
+        msgs.find(|m| {
             matches!(
                 m,
-                NetworkMessage::GetCFHeaders(GetCFHeaders {
-                    start_height,
-                    stop_hash,
-                    ..
-                }) if (*start_height as usize) == (cfheader_height + 1) && stop_hash == &chain.last().block_hash()
+                NetworkMessage::GetCFHeaders(
+                    GetCFHeaders { start_height, stop_hash, .. }
+                ) if (*start_height as usize) == (cfheader_height + 1) && stop_hash == &tip.block_hash()
             )
-        });
-        assert_matches!(msg, Some(..), "expect GetCFHeaders request");
+        }).expect("GetCFHeaders request");
     }
 
     // TODO: Test cache with partial cache hit

--- a/p2p/src/protocol/cbfmgr.rs
+++ b/p2p/src/protocol/cbfmgr.rs
@@ -1496,12 +1496,11 @@ mod tests {
         );
 
         let mut events = util::events(cbfmgr.upstream.drain());
-        let ev = events
-            .find(|e| {
-                matches!(e, Event::Syncing{start_height, stop_hash, ..}
+        let ev = events.find(|e| {
+            matches!(e, Event::Syncing{start_height, stop_hash, ..}
                                if (*start_height as usize) == (cfheader_height + 1)
                                && stop_hash == &chain.last().block_hash())
-            });
+        });
         assert_matches!(ev, Some(..), "expect syncing event emitted");
 
         let mut msgs = output::test::messages(&mut cbfmgr.upstream, &remote);

--- a/p2p/src/protocol/cbfmgr.rs
+++ b/p2p/src/protocol/cbfmgr.rs
@@ -1456,9 +1456,66 @@ mod tests {
     /// Test that if we start with our cfheader chain behind our header
     /// chain, we immediately try to catch up.
     #[test]
-    #[ignore]
     fn test_cfheaders_behind() {
-        todo!()
+        let cfheader_height = 10;
+        let header_height = 15;
+
+        let network = Network::Regtest;
+        let remote: PeerId = ([88, 88, 88, 88], 8333).into();
+        let mut rng = fastrand::Rng::with_seed(772092983);
+        let time = LocalTime::now();
+
+        let mut cbfmgr = {
+            let cache = FilterCache::from(store::memory::Memory::genesis(network)).unwrap();
+            let rng = fastrand::Rng::new();
+            let upstream = Outbox::new(network, PROTOCOL_VERSION, "test");
+            FilterManager::new(Config::default(), rng, cache, upstream)
+        };
+
+        let chain = gen::blockchain(network.genesis_block(), header_height, &mut rng);
+        let cfheaders = gen::cfheaders_from_blocks(
+            FilterHeader::genesis(network),
+            chain.tail.iter().take(cfheader_height),
+        );
+        cbfmgr.filters.import_headers(cfheaders).unwrap();
+
+        let tree = {
+            let params = network.params();
+            let headers = NonEmpty::from_vec(chain.iter().map(|b| b.header).collect()).unwrap();
+            BlockCache::from(store::Memory::new(headers), params, &[]).unwrap()
+        };
+        cbfmgr.initialize(time, &tree);
+
+        cbfmgr.peer_negotiated(
+            Socket::new(remote),
+            header_height,
+            REQUIRED_SERVICES,
+            Link::Outbound,
+            &time,
+            &tree,
+        );
+
+        let mut events = util::events(cbfmgr.upstream.drain());
+        let ev = events
+            .find(|e| {
+                matches!(e, Event::Syncing{start_height, stop_hash, ..}
+                               if (*start_height as usize) == (cfheader_height + 1)
+                               && stop_hash == &chain.last().block_hash())
+            });
+        assert_matches!(ev, Some(..), "expect syncing event emitted");
+
+        let mut msgs = output::test::messages(&mut cbfmgr.upstream, &remote);
+        let msg = msgs.find(|m| {
+            matches!(
+                m,
+                NetworkMessage::GetCFHeaders(GetCFHeaders {
+                    start_height,
+                    stop_hash,
+                    ..
+                }) if (*start_height as usize) == (cfheader_height + 1) && stop_hash == &chain.last().block_hash()
+            )
+        });
+        assert_matches!(msg, Some(..), "expect GetCFHeaders request");
     }
 
     // TODO: Test cache with partial cache hit


### PR DESCRIPTION
Make sure the manager attempts to catch up to the block headers when behind.

---
Help fund my contributions to this project at https://funding.server.ky/project/nakamoto