### PR TITLE
Refactor time/clock usage

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,6 +19,7 @@ jobs:
         run: cargo build --verbose
         env:
           RUSTFLAGS: -D warnings
+          RUST_BACKTRACE: 1
       - name: Run tests
         run: cargo test --all --verbose
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -20,7 +20,7 @@ use nakamoto_common::bitcoin::network::constants::ServiceFlags;
 use nakamoto_common::bitcoin::network::message::NetworkMessage;
 use nakamoto_common::bitcoin::network::Address;
 use nakamoto_common::block::store::{Genesis as _, Store as _};
-use nakamoto_common::block::time::AdjustedTime;
+use nakamoto_common::block::time::{AdjustedTime, RefClock};
 use nakamoto_common::block::tree::{self, BlockReader, ImportResult};
 use nakamoto_common::block::{BlockHash, BlockHeader, Height, Transaction};
 use nakamoto_common::nonempty::NonEmpty;
@@ -311,7 +311,14 @@ impl<R: Reactor<Publisher>> Client<R> {
 
         self.reactor.run(
             &listen,
-            Protocol::new(cache, filters, peers, clock, rng, config.protocol),
+            Protocol::new(
+                cache,
+                filters,
+                peers,
+                RefClock::from(clock),
+                rng,
+                config.protocol,
+            ),
         )?;
 
         Ok(())

--- a/client/src/tests/mock.rs
+++ b/client/src/tests/mock.rs
@@ -39,7 +39,12 @@ pub struct Client {
     pub filters: chan::Sender<(BlockFilter, BlockHash, Height)>,
     pub subscriber: event::Broadcast<protocol::Event, Event>,
     pub commands: chan::Receiver<Command>,
-    pub protocol: Protocol<model::Cache, model::FilterCache, HashMap<net::IpAddr, KnownAddress>>,
+    pub protocol: Protocol<
+        model::Cache,
+        model::FilterCache,
+        HashMap<net::IpAddr, KnownAddress>,
+        AdjustedTime<net::SocketAddr>,
+    >,
 
     // Used in handle.
     events_: chan::Receiver<protocol::Event>,

--- a/net/poll/src/reactor.rs
+++ b/net/poll/src/reactor.rs
@@ -157,11 +157,11 @@ impl<E: protocol::event::Publisher> nakamoto_p2p::traits::Reactor<E>
             let result = self.sources.wait_timeout(&mut events, timeout); // Blocking.
             let local_time = SystemTime::now().into();
 
+            protocol.tick(local_time);
+
             match result {
                 Ok(()) => {
                     trace!("Woke up with {} source(s) ready", events.len());
-
-                    protocol.tick(local_time);
 
                     for (source, ev) in events.iter() {
                         match source {
@@ -236,7 +236,7 @@ impl<E: protocol::event::Publisher> nakamoto_p2p::traits::Reactor<E>
 
                     if !timeouts.is_empty() {
                         timeouts.clear();
-                        protocol.tock(local_time);
+                        protocol.wake();
                     }
                 }
                 Err(err) => return Err(err.into()),

--- a/p2p/src/protocol/tests/simulator.rs
+++ b/p2p/src/protocol/tests/simulator.rs
@@ -367,7 +367,7 @@ impl Simulation {
                             p.protocol.disconnected(&addr, reason);
                         }
                     }
-                    Input::Tock => p.protocol.tock(self.time),
+                    Input::Tock => p.protocol.wake(),
                     Input::Received(addr, msg) => {
                         p.protocol.received_bytes(&addr, &msg);
                     }

--- a/p2p/src/traits.rs
+++ b/p2p/src/traits.rs
@@ -42,9 +42,8 @@ pub trait Protocol {
     /// "a regular short, sharp sound, especially that made by a clock or watch, typically
     /// every second."
     fn tick(&mut self, local_time: LocalTime);
-    /// Used to advance the state machine after some wall time has passed, typically
-    /// after a timer rings.
-    fn tock(&mut self, local_time: LocalTime);
+    /// Used to advance the state machine after some timer rings.
+    fn wake(&mut self);
     /// Drain all protocol outputs since the last call.
     fn drain(&mut self) -> Self::Drain;
     /// Write the peer's output buffer to the given writer.


### PR DESCRIPTION
We provide a shared clock object that is passed to sub-protocols
instead of passing the time into every function that needs it.