### PR TITLE
Upgrade rust-bitcoin to v0.28.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
 
 [[package]]
 name = "bitcoin"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a41df6ad9642c5c15ae312dd3d074de38fd3eb7cc87ad4ce10f90292a83fe4d"
+checksum = "42b2a9a8e3c7544f5ce2b475f2f56580a3102b37e0ee001558ad4faedcf56cf4"
 dependencies = [
  "bech32",
  "bitcoin_hashes",
@@ -508,18 +508,18 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.20.3"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d03ceae636d0fed5bae6a7f4f664354c5f4fcedf6eef053fef17e49f837d0a"
+checksum = "26947345339603ae8395f68e2f3d85a6b0a8ddfe6315818e80b8504415099db0"
 dependencies = [
  "secp256k1-sys",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827cb7cce42533829c792fc51b82fbf18b125b45a702ef2c8be77fce65463a7b"
+checksum = "07b5b9d7322572e1f3aeed208668ce87789b3645dbb73082c5ce99a004103a35"
 dependencies = [
  "cc",
 ]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Alexis Sellier <self@cloudhead.io>"]
 edition = "2021"
 
 [dependencies]
-bitcoin = "0.27.0"
+bitcoin = "0.28.0"
 bitcoin_hashes = "0.10.0"
 thiserror = "1.0"
 fastrand = "1.3.5"

--- a/p2p/src/protocol/fees.rs
+++ b/p2p/src/protocol/fees.rs
@@ -177,7 +177,7 @@ impl FeeEstimator {
         assert!(received >= sent, "you can't spend what you don't have",);
 
         let fee = received - sent;
-        let weight = tx.get_weight();
+        let weight = tx.weight();
         let rate = fee as f64 / (weight as f64 / WITNESS_SCALE_FACTOR as f64);
 
         Some(rate.round() as FeeRate)

--- a/test/src/block.rs
+++ b/test/src/block.rs
@@ -66,7 +66,7 @@ pub mod gen {
     use bitcoin::util::bip158;
     use bitcoin::util::uint::Uint256;
 
-    use nakamoto_common::bitcoin;
+    use nakamoto_common::bitcoin::{self, Witness};
     use nakamoto_common::bitcoin_hashes::{hash160, Hash as _};
     use nakamoto_common::block::filter::{BlockFilter, FilterHash, FilterHeader};
     use nakamoto_common::block::*;
@@ -93,7 +93,7 @@ pub mod gen {
                 },
                 script_sig: Script::new(),
                 sequence: 0xFFFFFFFF,
-                witness: vec![],
+                witness: Witness::new(),
             };
             input.push(inp);
         }
@@ -125,7 +125,7 @@ pub mod gen {
             previous_output,
             script_sig: Script::new(),
             sequence: 0xFFFFFFFF,
-            witness: vec![],
+            witness: Witness::new(),
         };
         let fee = rng.u64(0..value);
         let mut allowance = value - fee;
@@ -183,7 +183,7 @@ pub mod gen {
             previous_output: OutPoint::null(),
             script_sig: Script::new(),
             sequence: 0xFFFFFFFF,
-            witness: vec![],
+            witness: Witness::new(),
         };
         Transaction {
             version: 1,
@@ -211,7 +211,7 @@ pub mod gen {
     ) -> Block {
         let merkle_root =
             bitcoin::util::hash::bitcoin_merkle_root(txdata.iter().map(|tx| tx.txid().as_hash()));
-        let merkle_root = TxMerkleNode::from_hash(merkle_root);
+        let merkle_root = TxMerkleNode::from_hash(merkle_root.unwrap_or_default());
         let header = header(prev_header, merkle_root, rng);
 
         Block { header, txdata }
@@ -247,7 +247,7 @@ pub mod gen {
         let txdata = vec![coinbase(rng)];
         let merkle_root =
             bitcoin::util::hash::bitcoin_merkle_root(txdata.iter().map(|tx| tx.txid().as_hash()));
-        let merkle_root = TxMerkleNode::from_hash(merkle_root);
+        let merkle_root = TxMerkleNode::from_hash(merkle_root.unwrap_or_default());
 
         let target = Uint256([
             0xffffffffffffffffu64,


### PR DESCRIPTION
Upgrading `rust-bitcoin` to `0.28.0`. There are a few breaking changes in terms of the API but nothing significant.