### PR TITLE
Make networking generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,7 @@ dependencies = [
  "nakamoto-chain",
  "nakamoto-client",
  "nakamoto-common",
+ "nakamoto-net",
  "nakamoto-net-poll",
  "nakamoto-node",
  "nakamoto-p2p",
@@ -259,6 +260,7 @@ dependencies = [
  "microserde",
  "nakamoto-chain",
  "nakamoto-common",
+ "nakamoto-net",
  "nakamoto-net-poll",
  "nakamoto-p2p",
  "nakamoto-test",
@@ -277,7 +279,17 @@ dependencies = [
  "fastrand",
  "log",
  "microserde",
+ "nakamoto-net",
  "nonempty",
+ "thiserror",
+]
+
+[[package]]
+name = "nakamoto-net"
+version = "0.3.0"
+dependencies = [
+ "crossbeam-channel",
+ "log",
  "thiserror",
 ]
 
@@ -290,8 +302,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nakamoto-common",
- "nakamoto-p2p",
+ "nakamoto-net",
  "popol",
  "quickcheck",
  "quickcheck_macros",
@@ -322,6 +333,7 @@ dependencies = [
  "microserde",
  "nakamoto-chain",
  "nakamoto-common",
+ "nakamoto-net",
  "nakamoto-test",
  "quickcheck",
  "quickcheck_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
   "test",
   "client",
   "wallet",
-  "net/poll",
+  "net",
 ]
 
 [features]
@@ -28,6 +28,7 @@ default = [
   "nakamoto-chain",
   "nakamoto-p2p",
   "nakamoto-common",
+  "nakamoto-net",
   "nakamoto-net-poll"
 ]
 
@@ -39,4 +40,5 @@ nakamoto-chain = { version = "0.3.0", path = "./chain", optional = true }
 nakamoto-p2p = { version = "0.3.0", path = "./p2p", optional = true }
 nakamoto-test = { version = "0.3.0", path = "./test", optional = true }
 nakamoto-wallet = { version = "0.3.0", path = "./wallet", optional = true }
+nakamoto-net = { version = "0.3.0", path = "./net", optional = true }
 nakamoto-net-poll = { version = "0.3.0", path = "./net/poll", optional = true }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ them, and the use of traits. From a high-level, we have:
 * `nakamoto-client`: the core light-client library
 * `nakamoto-p2p`: the protocol state-machine implementation
 * `nakamoto-chain`: the block store and fork selection logic
-* `nakamoto-net-poll`: the default *poll*-based networking library
+* `nakamoto-net`: networking primitives used by the reactor implementations
+* `nakamoto-net-poll`: the default *poll*-based networking backend
 * `nakamoto-common`: common functionality used by all crates
 * `nakamoto-node`: a standalone light-client daemon
 * `nakamoto-wallet`: a very basic watch-only wallet built on the above crates

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 
 [dependencies]
 nakamoto-p2p = { version = "0.3.0", path = "../p2p" }
+nakamoto-net = { version = "0.3.0", path = "../net" }
 nakamoto-chain = { version = "0.3.0", path = "../chain" }
 nakamoto-common = { version = "0.3.0", path = "../common" }
 crossbeam-channel = { version = "0.5.6" }

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -16,9 +16,9 @@ pub enum Error {
     /// An error occuring from a client handle.
     #[error(transparent)]
     Handle(#[from] crate::handle::Error),
-    /// An error coming from the peer-to-peer sub-system.
+    /// An error coming from the networking sub-system.
     #[error(transparent)]
-    P2p(#[from] p2p::error::Error),
+    Net(#[from] nakamoto_net::error::Error),
     /// A chain-related error.
     #[error(transparent)]
     Chain(#[from] common::block::tree::Error),

--- a/client/src/event.rs
+++ b/client/src/event.rs
@@ -6,8 +6,10 @@ use std::sync::Arc;
 use nakamoto_common::bitcoin::network::constants::ServiceFlags;
 use nakamoto_common::bitcoin::{Transaction, Txid};
 use nakamoto_common::block::{BlockHash, BlockHeader, Height};
+use nakamoto_net::DisconnectReason;
+use nakamoto_p2p::protocol;
 use nakamoto_p2p::protocol::fees::FeeEstimate;
-use nakamoto_p2p::protocol::{DisconnectReason, Link, PeerId};
+use nakamoto_p2p::protocol::{Link, PeerId};
 
 use crate::spv::TxStatus;
 
@@ -36,7 +38,7 @@ pub enum Event {
         /// Peer address.
         addr: PeerId,
         /// Reason for disconnection.
-        reason: DisconnectReason,
+        reason: DisconnectReason<protocol::DisconnectReason>,
     },
     /// Connection was never established and timed out or failed.
     PeerConnectionFailed {

--- a/client/src/spv.rs
+++ b/client/src/spv.rs
@@ -9,11 +9,9 @@ mod tests;
 use std::collections::HashSet;
 use std::{fmt, net};
 
-use p2p::event::Emitter;
-
 use nakamoto_common::bitcoin::{Block, Txid};
-
 use nakamoto_common::block::{BlockHash, Height};
+use nakamoto_net::event::Emitter;
 use nakamoto_p2p as p2p;
 use p2p::protocol;
 

--- a/client/src/spv/tests.rs
+++ b/client/src/spv/tests.rs
@@ -44,17 +44,16 @@ use quickcheck_macros::quickcheck;
 
 use nakamoto_common::bitcoin::OutPoint;
 
-use nakamoto_common::block::time::LocalTime;
+use nakamoto_common::block::time::Clock as _;
 use nakamoto_common::network::Network;
 use nakamoto_common::nonempty::NonEmpty;
+use nakamoto_net::{DisconnectReason, Link, LocalTime, Protocol as _};
 use nakamoto_test::assert_matches;
 use nakamoto_test::block::gen;
 use nakamoto_test::logger;
 
-use p2p::protocol::{Command, DisconnectReason};
-use p2p::traits::Protocol as _;
+use p2p::protocol::Command;
 
-use super::p2p::protocol::Link;
 use super::utxos::Utxos;
 use super::Event;
 use super::*;

--- a/client/src/tests/mock.rs
+++ b/client/src/tests/mock.rs
@@ -19,13 +19,13 @@ use nakamoto_common::nonempty::NonEmpty;
 use nakamoto_common::p2p::peer::KnownAddress;
 use nakamoto_test::block::cache::model;
 
-use nakamoto_p2p::event;
+use nakamoto_net::event;
+use nakamoto_net::Protocol as _;
 use nakamoto_p2p::protocol;
 use nakamoto_p2p::protocol::Command;
 use nakamoto_p2p::protocol::Link;
 use nakamoto_p2p::protocol::Peer;
 use nakamoto_p2p::protocol::Protocol;
-use nakamoto_p2p::traits::Protocol as _;
 
 use crate::client::{chan, Event};
 use crate::handle::{self, Handle};

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["Alexis Sellier <self@cloudhead.io>"]
 edition = "2021"
 
 [dependencies]
+nakamoto-net = { version = "0.3.0", path = "../net" }
 bitcoin = "0.28.0"
 bitcoin_hashes = "0.10.0"
 thiserror = "1.0"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -8,6 +8,7 @@ pub mod p2p;
 
 pub use bitcoin;
 pub use bitcoin_hashes;
+pub use nakamoto_net as net;
 pub use nonempty;
 
 /// Return the function path at the current source location.

--- a/common/src/p2p/peer.rs
+++ b/common/src/p2p/peer.rs
@@ -8,7 +8,8 @@ use microserde as serde;
 use bitcoin::network::address::Address;
 use bitcoin::network::constants::ServiceFlags;
 
-use crate::block::time::LocalTime;
+use crate::block::time::Clock;
+use crate::net::time::LocalTime;
 
 /// Peer store.
 ///

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nakamoto-net"
+description = "Lightweight peer-to-peer networking"
+homepage = "https://cloudhead.io/nakamoto/"
+documentation = "https://docs.rs/nakamoto-net"
+repository = "https://github.com/cloudhead/nakamoto"
+version = "0.3.0"
+authors = ["Alexis Sellier <self@cloudhead.io>"]
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+log = "0.4"
+thiserror = "1.0"
+crossbeam-channel = { version = "0.5.6" }

--- a/net/poll/Cargo.toml
+++ b/net/poll/Cargo.toml
@@ -9,8 +9,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-nakamoto-common = { version = "0.3.0", path = "../../common" }
-nakamoto-p2p = { version = "0.3.0", path = "../../p2p" }
+nakamoto-net = { version = "0.3.0", path = ".." }
 crossbeam-channel = { version = "0.5.6" }
 popol = "0.5"
 socket2 = "0.4"

--- a/net/poll/src/socket.rs
+++ b/net/poll/src/socket.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use std::io::{self, Read, Write};
 use std::net;
 
-use nakamoto_p2p::protocol::Link;
+use nakamoto_net::Link;
 
 use crate::fallible;
 

--- a/net/poll/src/time.rs
+++ b/net/poll/src/time.rs
@@ -1,6 +1,5 @@
 //! Time-related functionality useful for reactors.
-
-pub use nakamoto_common::block::time::{LocalDuration, LocalTime};
+pub use nakamoto_net::time::{LocalDuration, LocalTime};
 
 /// Manages timers and triggers timeouts.
 pub struct TimeoutManager<K> {

--- a/net/src/error.rs
+++ b/net/src/error.rs
@@ -1,7 +1,5 @@
 //! Peer-to-peer protocol errors.
 
-use nakamoto_common::bitcoin::consensus::encode;
-
 use std::fmt::Debug;
 use std::io;
 
@@ -15,10 +13,6 @@ pub enum Error {
     /// An I/O error.
     #[error("i/o error: {0}")]
     Io(#[from] io::Error),
-
-    /// An encoding/decoding error.
-    #[error("encode/decode error: {0}")]
-    Encode(#[from] encode::Error),
 
     /// A channel send or receive error.
     #[error("channel error: {0}")]

--- a/net/src/event.rs
+++ b/net/src/event.rs
@@ -103,3 +103,16 @@ where
         }
     }
 }
+
+/// Any type that is able to publish events.
+pub trait Publisher<E>: Send + Sync {
+    /// Publish an event.
+    fn publish(&mut self, event: E);
+}
+
+impl<E, T: Clone + Send + Sync> Publisher<E> for Broadcast<E, T> {
+    /// Publish a message to all subscribers.
+    fn publish(&mut self, event: E) {
+        self.broadcast(event)
+    }
+}

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -1,19 +1,83 @@
-//! P2P related traits.
-use std::{io, net};
+//! Peer-to-peer networking core types.
+#![allow(clippy::type_complexity)]
+use std::sync::Arc;
+use std::{fmt, io, net};
 
 use crossbeam_channel as chan;
-use nakamoto_common::block::time::LocalTime;
 
-use crate::error::Error;
-use crate::protocol::event::Publisher;
-use crate::protocol::{Command, DisconnectReason, Io, Link};
+pub mod error;
+pub mod event;
+pub mod time;
+
+pub use event::Publisher;
+pub use time::{LocalDuration, LocalTime};
+
+/// Link direction of the peer connection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Link {
+    /// Inbound conneciton.
+    Inbound,
+    /// Outbound connection.
+    Outbound,
+}
+
+impl Link {
+    /// Check whether the link is outbound.
+    pub fn is_outbound(&self) -> bool {
+        *self == Link::Outbound
+    }
+
+    /// Check whether the link is inbound.
+    pub fn is_inbound(&self) -> bool {
+        *self == Link::Inbound
+    }
+}
+
+/// Output of a state transition of the `Protocol` state machine.
+#[derive(Debug)]
+pub enum Io<E, D> {
+    /// There are some bytes ready to be sent to a peer.
+    Write(net::SocketAddr),
+    /// Connect to a peer.
+    Connect(net::SocketAddr),
+    /// Disconnect from a peer.
+    Disconnect(net::SocketAddr, DisconnectReason<D>),
+    /// Ask for a wakeup in a specified amount of time.
+    Wakeup(LocalDuration),
+    /// Emit an event.
+    Event(E),
+}
+
+/// Disconnect reason.
+#[derive(Debug, Clone)]
+pub enum DisconnectReason<T> {
+    /// Error with the underlying connection.
+    ConnectionError(Arc<std::io::Error>),
+    /// Peer was disconnected for another reason.
+    Protocol(T),
+}
+
+impl<T: fmt::Display> fmt::Display for DisconnectReason<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ConnectionError(err) => write!(f, "connection error: {}", err),
+            Self::Protocol(reason) => write!(f, "{}", reason),
+        }
+    }
+}
 
 /// A protocol state-machine.
 ///
-/// This trait is implemented by the core P2P protocol in [`crate::protocol::Protocol`].
+/// Network protocols must implement this trait to be drivable by the reactor.
 pub trait Protocol {
+    /// Events emitted by the protocol.
+    type Event: fmt::Debug;
+    /// Reason a peer was disconnected.
+    type DisconnectReason: fmt::Debug + fmt::Display;
+    /// User commands handled by protocol.
+    type Command;
     /// Return type of [`Protocol::drain`].
-    type Drain: Iterator<Item = Io>;
+    type Drain: Iterator<Item = Io<Self::Event, Self::DisconnectReason>>;
 
     /// Initialize the protocol. Called once before any event is sent to the state machine.
     fn initialize(&mut self, _time: LocalTime) {
@@ -34,9 +98,13 @@ pub trait Protocol {
     /// New connection with a peer.
     fn connected(&mut self, addr: net::SocketAddr, local_addr: &net::SocketAddr, link: Link);
     /// Disconnected from peer.
-    fn disconnected(&mut self, addr: &net::SocketAddr, reason: DisconnectReason);
+    fn disconnected(
+        &mut self,
+        addr: &net::SocketAddr,
+        reason: DisconnectReason<Self::DisconnectReason>,
+    );
     /// An external command has been received.
-    fn command(&mut self, cmd: Command);
+    fn command(&mut self, cmd: Self::Command);
     /// Used to update the protocol's internal clock.
     ///
     /// "a regular short, sharp sound, especially that made by a clock or watch, typically
@@ -53,27 +121,27 @@ pub trait Protocol {
 }
 
 /// Any network reactor that can drive the light-client protocol.
-pub trait Reactor<E: Publisher> {
+pub trait Reactor {
     /// The type of waker this reactor uses.
     type Waker: Send + Clone;
 
     /// Create a new reactor, initializing it with a publisher for protocol events,
     /// a channel to receive commands, and a channel to shut it down.
     fn new(
-        publisher: E,
-        commands: chan::Receiver<Command>,
         shutdown: chan::Receiver<()>,
+        listening: chan::Sender<net::SocketAddr>,
     ) -> Result<Self, io::Error>
     where
-        E: Publisher,
         Self: Sized;
 
     /// Run the given protocol state machine with the reactor.
-    fn run<P: Protocol>(
+    fn run<P: Protocol, E: Publisher<P::Event>>(
         &mut self,
         listen_addrs: &[net::SocketAddr],
         protocol: P,
-    ) -> Result<(), Error>;
+        publisher: E,
+        commands: chan::Receiver<P::Command>,
+    ) -> Result<(), error::Error>;
 
     /// Used to wake certain types of reactors.
     fn wake(waker: &Self::Waker) -> io::Result<()>;

--- a/net/src/time.rs
+++ b/net/src/time.rs
@@ -1,0 +1,234 @@
+use std::sync::atomic;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Local time.
+///
+/// This clock is monotonic.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Ord, PartialOrd, Default)]
+pub struct LocalTime {
+    /// Milliseconds since Epoch.
+    millis: u128,
+}
+
+impl std::fmt::Display for LocalTime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_secs())
+    }
+}
+
+impl LocalTime {
+    /// Construct a local time from the current system time.
+    pub fn now() -> Self {
+        static LAST: atomic::AtomicU64 = atomic::AtomicU64::new(0);
+
+        let now = Self::from(SystemTime::now()).as_secs();
+        let last = LAST.load(atomic::Ordering::SeqCst);
+
+        // If the current time is in the past, return the last recorded time instead.
+        if now < last {
+            Self::from_secs(last)
+        } else {
+            LAST.store(now, atomic::Ordering::SeqCst);
+            LocalTime::from_secs(now)
+        }
+    }
+
+    /// Construct a local time from whole seconds since Epoch.
+    pub const fn from_secs(secs: u64) -> Self {
+        Self {
+            millis: secs as u128 * 1000,
+        }
+    }
+
+    /// Construct a local time to whole seconds since Epoch.
+    pub fn as_secs(&self) -> u64 {
+        (self.millis / 1000).try_into().unwrap()
+    }
+
+    /// Get the duration since the given time.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `earlier` is later than `self`.
+    pub fn duration_since(&self, earlier: LocalTime) -> LocalDuration {
+        LocalDuration::from_millis(
+            self.millis
+                .checked_sub(earlier.millis)
+                .expect("supplied time is later than self"),
+        )
+    }
+
+    /// Get the difference between two times.
+    pub fn diff(&self, other: LocalTime) -> LocalDuration {
+        if self > &other {
+            self.duration_since(other)
+        } else {
+            other.duration_since(*self)
+        }
+    }
+
+    /// Elapse time.
+    ///
+    /// Adds the given duration to the time.
+    pub fn elapse(&mut self, duration: LocalDuration) {
+        self.millis += duration.as_millis()
+    }
+}
+
+/// Convert a `SystemTime` into a local time.
+impl From<SystemTime> for LocalTime {
+    fn from(system: SystemTime) -> Self {
+        let millis = system.duration_since(UNIX_EPOCH).unwrap().as_millis();
+
+        Self { millis }
+    }
+}
+
+/// Substract two local times. Yields a duration.
+impl std::ops::Sub<LocalTime> for LocalTime {
+    type Output = LocalDuration;
+
+    fn sub(self, other: LocalTime) -> LocalDuration {
+        LocalDuration(self.millis.saturating_sub(other.millis))
+    }
+}
+
+/// Substract a duration from a local time. Yields a local time.
+impl std::ops::Sub<LocalDuration> for LocalTime {
+    type Output = LocalTime;
+
+    fn sub(self, other: LocalDuration) -> LocalTime {
+        LocalTime {
+            millis: self.millis - other.0,
+        }
+    }
+}
+
+/// Add a duration to a local time. Yields a local time.
+impl std::ops::Add<LocalDuration> for LocalTime {
+    type Output = LocalTime;
+
+    fn add(self, other: LocalDuration) -> LocalTime {
+        LocalTime {
+            millis: self.millis + other.0,
+        }
+    }
+}
+
+/// Time duration as measured locally.
+#[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]
+pub struct LocalDuration(u128);
+
+impl LocalDuration {
+    /// The time interval between blocks. The "block time".
+    pub const BLOCK_INTERVAL: LocalDuration = Self::from_mins(10);
+
+    /// Maximum duration.
+    pub const MAX: LocalDuration = LocalDuration(u128::MAX);
+
+    /// Create a new duration from whole seconds.
+    pub const fn from_secs(secs: u64) -> Self {
+        Self(secs as u128 * 1000)
+    }
+
+    /// Create a new duration from whole minutes.
+    pub const fn from_mins(mins: u64) -> Self {
+        Self::from_secs(mins * 60)
+    }
+
+    /// Construct a new duration from milliseconds.
+    pub const fn from_millis(millis: u128) -> Self {
+        Self(millis)
+    }
+
+    /// Return the number of minutes in this duration.
+    pub const fn as_mins(&self) -> u64 {
+        self.as_secs() / 60
+    }
+
+    /// Return the number of seconds in this duration.
+    pub const fn as_secs(&self) -> u64 {
+        (self.0 / 1000) as u64
+    }
+
+    /// Return the number of milliseconds in this duration.
+    pub const fn as_millis(&self) -> u128 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for LocalDuration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.as_millis() < 1000 {
+            write!(f, "{} millisecond(s)", self.as_millis())
+        } else if self.as_secs() < 60 {
+            let fraction = self.as_millis() % 1000;
+            if fraction > 0 {
+                write!(f, "{}.{} second(s)", self.as_secs(), fraction)
+            } else {
+                write!(f, "{} second(s)", self.as_secs())
+            }
+        } else if self.as_mins() < 60 {
+            let fraction = self.as_secs() % 60;
+            if fraction > 0 {
+                write!(
+                    f,
+                    "{:.2} minutes(s)",
+                    self.as_mins() as f64 + (fraction as f64 / 60.)
+                )
+            } else {
+                write!(f, "{} minutes(s)", self.as_mins())
+            }
+        } else {
+            let fraction = self.as_mins() % 60;
+            if fraction > 0 {
+                write!(f, "{:.2} hour(s)", self.as_mins() as f64 / 60.)
+            } else {
+                write!(f, "{} hour(s)", self.as_mins() / 60)
+            }
+        }
+    }
+}
+
+impl<'a> std::iter::Sum<&'a LocalDuration> for LocalDuration {
+    fn sum<I: Iterator<Item = &'a LocalDuration>>(iter: I) -> LocalDuration {
+        let mut total: u128 = 0;
+
+        for entry in iter {
+            total = total
+                .checked_add(entry.0)
+                .expect("iter::sum should not overflow");
+        }
+        Self(total)
+    }
+}
+
+impl std::ops::Add<LocalDuration> for LocalDuration {
+    type Output = LocalDuration;
+
+    fn add(self, other: LocalDuration) -> LocalDuration {
+        LocalDuration(self.0 + other.0)
+    }
+}
+
+impl std::ops::Div<u32> for LocalDuration {
+    type Output = LocalDuration;
+
+    fn div(self, other: u32) -> LocalDuration {
+        LocalDuration(self.0 / other as u128)
+    }
+}
+
+impl std::ops::Mul<u64> for LocalDuration {
+    type Output = LocalDuration;
+
+    fn mul(self, other: u64) -> LocalDuration {
+        LocalDuration(self.0 * other as u128)
+    }
+}
+
+impl From<LocalDuration> for std::time::Duration {
+    fn from(other: LocalDuration) -> Self {
+        std::time::Duration::from_millis(other.0 as u64)
+    }
+}

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -13,7 +13,7 @@ use nakamoto_client::protocol;
 pub mod logger;
 
 /// The network reactor we're going to use.
-type Reactor = nakamoto_net_poll::Reactor<net::TcpStream, client::Publisher>;
+type Reactor = nakamoto_net_poll::Reactor<net::TcpStream>;
 
 /// Run the light-client. Takes an initial list of peers to connect to, a list of listen addresses,
 /// the client root and the Bitcoin network to connect to.

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 
 [dependencies]
 nakamoto-common = { version = "0.3.0", path = "../common" }
+nakamoto-net = { version = "0.3.0", path = "../net" }
 log = "0.4"
 thiserror = "1.0"
 crossbeam-channel = { version = "0.5.6" }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -24,10 +24,8 @@
 #![allow(clippy::inconsistent_struct_constructor)]
 #![allow(clippy::too_many_arguments)]
 #![deny(missing_docs, unsafe_code)]
-pub mod error;
-pub mod event;
 pub mod protocol;
 pub mod stream;
-pub mod traits;
 
+pub use nakamoto_net as net;
 pub use protocol::{Link, PeerId};

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -34,10 +34,10 @@ pub use peermgr::Event as PeerEvent;
 pub use syncmgr::Event as ChainEvent;
 
 use crate::stream;
-use crate::traits;
 
 pub use event::Event;
-pub use output::{DisconnectReason, Io};
+pub use nakamoto_net::Link;
+pub use output::Io;
 
 use std::collections::{HashMap, HashSet};
 use std::fmt::{self, Debug};
@@ -46,6 +46,7 @@ use std::sync::Arc;
 use std::{io, net};
 
 use nakamoto_common::bitcoin::blockdata::block::BlockHeader;
+use nakamoto_common::bitcoin::consensus::encode;
 use nakamoto_common::bitcoin::consensus::params::Params;
 use nakamoto_common::bitcoin::network::constants::ServiceFlags;
 use nakamoto_common::bitcoin::network::message::{NetworkMessage, RawNetworkMessage};
@@ -54,9 +55,8 @@ use nakamoto_common::bitcoin::network::message_filter::GetCFilters;
 use nakamoto_common::bitcoin::network::message_network::VersionMessage;
 use nakamoto_common::bitcoin::network::Address;
 use nakamoto_common::bitcoin::Script;
-use nakamoto_common::block::time::AdjustedClock;
-
 use nakamoto_common::block::filter::Filters;
+use nakamoto_common::block::time::AdjustedClock;
 use nakamoto_common::block::time::{LocalDuration, LocalTime};
 use nakamoto_common::block::tree::{self, BlockReader, BlockTree, ImportResult};
 use nakamoto_common::block::{BlockHash, Height};
@@ -116,6 +116,71 @@ impl From<net::SocketAddr> for Socket {
     }
 }
 
+/// Disconnect reason.
+#[derive(Debug, Clone)]
+pub enum DisconnectReason {
+    /// Peer is misbehaving.
+    PeerMisbehaving(&'static str),
+    /// Peer protocol version is too old or too recent.
+    PeerProtocolVersion(u32),
+    /// Peer doesn't have the required services.
+    PeerServices(ServiceFlags),
+    /// Peer chain is too far behind.
+    PeerHeight(Height),
+    /// Peer magic is invalid.
+    PeerMagic(u32),
+    /// Peer timed out.
+    PeerTimeout(&'static str),
+    /// Peer was dropped by all sub-protocols.
+    PeerDropped,
+    /// Connection to self was detected.
+    SelfConnection,
+    /// Inbound connection limit reached.
+    ConnectionLimit,
+    /// Error trying to decode incoming message.
+    DecodeError(Arc<encode::Error>),
+    /// Peer was forced to disconnect by external command.
+    Command,
+    /// Peer was disconnected for another reason.
+    Other(&'static str),
+}
+
+impl DisconnectReason {
+    /// Check whether the disconnect reason is transient, ie. may no longer be applicable
+    /// after some time.
+    pub fn is_transient(&self) -> bool {
+        matches!(
+            self,
+            Self::ConnectionLimit | Self::PeerTimeout(_) | Self::PeerHeight(_)
+        )
+    }
+}
+
+impl From<DisconnectReason> for nakamoto_net::DisconnectReason<DisconnectReason> {
+    fn from(reason: DisconnectReason) -> Self {
+        Self::Protocol(reason)
+    }
+}
+
+impl fmt::Display for DisconnectReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PeerMisbehaving(reason) => write!(f, "peer misbehaving: {}", reason),
+            Self::PeerProtocolVersion(_) => write!(f, "peer protocol version mismatch"),
+            Self::PeerServices(_) => write!(f, "peer doesn't have the required services"),
+            Self::PeerHeight(_) => write!(f, "peer is too far behind"),
+            Self::PeerMagic(magic) => write!(f, "received message with invalid magic: {}", magic),
+            Self::PeerTimeout(s) => write!(f, "peer timed out: {:?}", s),
+            Self::PeerDropped => write!(f, "peer dropped"),
+            Self::SelfConnection => write!(f, "detected self-connection"),
+            Self::ConnectionLimit => write!(f, "inbound connection limit reached"),
+            Self::DecodeError(err) => write!(f, "message decode error: {}", err),
+            Self::Command => write!(f, "received external command"),
+            Self::Other(reason) => write!(f, "{}", reason),
+        }
+    }
+}
+
 /// A remote peer.
 #[derive(Debug, Clone)]
 pub struct Peer {
@@ -156,27 +221,6 @@ impl From<(&peermgr::PeerInfo, &peermgr::Connection)> for Peer {
             user_agent: peer.user_agent.clone(),
             relay: peer.relay,
         }
-    }
-}
-
-/// Link direction of the peer connection.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Link {
-    /// Inbound conneciton.
-    Inbound,
-    /// Outbound connection.
-    Outbound,
-}
-
-impl Link {
-    /// Check whether the link is outbound.
-    pub fn is_outbound(&self) -> bool {
-        *self == Link::Outbound
-    }
-
-    /// Check whether the link is inbound.
-    pub fn is_inbound(&self) -> bool {
-        *self == Link::Inbound
     }
 }
 
@@ -768,10 +812,13 @@ impl<T: BlockTree, F: Filters, P: peer::Store, C: AdjustedClock<PeerId>> Protoco
     }
 }
 
-impl<T: BlockTree, F: Filters, P: peer::Store, C: AdjustedClock<PeerId>> traits::Protocol
+impl<T: BlockTree, F: Filters, P: peer::Store, C: AdjustedClock<PeerId>> nakamoto_net::Protocol
     for Protocol<T, F, P, C>
 {
+    type Event = Event;
+    type DisconnectReason = DisconnectReason;
     type Drain = output::Drain;
+    type Command = Command;
 
     fn initialize(&mut self, time: LocalTime) {
         self.clock.set(time);
@@ -801,10 +848,11 @@ impl<T: BlockTree, F: Filters, P: peer::Store, C: AdjustedClock<PeerId>> traits:
         self.inbox
             .insert(addr, stream::Decoder::new(INBOX_BUFFER_SIZE));
     }
-
-    fn disconnected(&mut self, addr: &net::SocketAddr, reason: DisconnectReason) {
-        info!(target: self.target, "[conn] {}: Disconnected: {}", addr, reason);
-
+    fn disconnected(
+        &mut self,
+        addr: &net::SocketAddr,
+        reason: nakamoto_net::DisconnectReason<DisconnectReason>,
+    ) {
         self.cbfmgr.peer_disconnected(addr);
         self.syncmgr.peer_disconnected(addr);
         self.addrmgr.peer_disconnected(addr, reason.clone());

--- a/p2p/src/protocol/event.rs
+++ b/p2p/src/protocol/event.rs
@@ -1,9 +1,6 @@
 //! Protocol events.
-use std::net;
-
 use nakamoto_common::bitcoin::network::message::NetworkMessage;
 
-use crate::event::Broadcast;
 use crate::protocol::{self, Height, LocalTime, PeerId};
 
 /// A peer-to-peer event.
@@ -20,8 +17,6 @@ pub enum Event {
         /// Local time.
         time: LocalTime,
     },
-    /// The node is now listening for incoming connections.
-    Listening(net::SocketAddr),
     /// Received a message from a peer.
     Received(PeerId, NetworkMessage),
     /// An address manager event.
@@ -34,17 +29,4 @@ pub enum Event {
     Filter(protocol::FilterEvent),
     /// An inventory manager event.
     Inventory(protocol::InventoryEvent),
-}
-
-/// Any type that is able to publish events.
-pub trait Publisher: Send + Sync {
-    /// Publish an event.
-    fn publish(&mut self, event: Event);
-}
-
-impl<T: Clone + Send + Sync> Publisher for Broadcast<Event, T> {
-    /// Publish a message to all subscribers.
-    fn publish(&mut self, event: Event) {
-        self.broadcast(event)
-    }
 }

--- a/p2p/src/protocol/output.rs
+++ b/p2p/src/protocol/output.rs
@@ -9,14 +9,11 @@ use log::*;
 use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
 use std::rc::Rc;
-use std::sync::Arc;
-use std::{fmt, io, net};
+use std::{io, net};
 
 pub use crossbeam_channel as chan;
 
-use nakamoto_common::bitcoin::consensus::encode;
 use nakamoto_common::bitcoin::network::address::Address;
-use nakamoto_common::bitcoin::network::constants::ServiceFlags;
 use nakamoto_common::bitcoin::network::message::NetworkMessage;
 use nakamoto_common::bitcoin::network::message_blockdata::{GetHeadersMessage, Inventory};
 use nakamoto_common::bitcoin::network::message_filter::{
@@ -34,91 +31,11 @@ use super::network::Network;
 use super::{addrmgr, cbfmgr, invmgr, peermgr, pingmgr, syncmgr, Locators};
 
 /// Output of a state transition of the `Protocol` state machine.
-#[derive(Debug)]
-pub enum Io {
-    /// There are some bytes ready to be sent to a peer.
-    Write(PeerId),
-    /// Connect to a peer.
-    Connect(PeerId),
-    /// Disconnect from a peer.
-    Disconnect(PeerId, DisconnectReason),
-    /// Ask for a wakeup in a specified amount of time.
-    Wakeup(LocalDuration),
-    /// Emit an event.
-    Event(Event),
-}
+pub type Io = nakamoto_net::Io<Event, super::DisconnectReason>;
 
 impl From<Event> for Io {
     fn from(event: Event) -> Self {
         Io::Event(event)
-    }
-}
-
-/// Disconnect reason.
-#[derive(Debug, Clone)]
-pub enum DisconnectReason {
-    /// Peer is misbehaving.
-    PeerMisbehaving(&'static str),
-    /// Peer protocol version is too old or too recent.
-    PeerProtocolVersion(u32),
-    /// Peer doesn't have the required services.
-    PeerServices(ServiceFlags),
-    /// Peer chain is too far behind.
-    PeerHeight(Height),
-    /// Peer magic is invalid.
-    PeerMagic(u32),
-    /// Peer timed out.
-    PeerTimeout(&'static str),
-    /// Peer disconnected us.
-    PeerDisconnected,
-    /// Peer was dropped by all sub-protocols.
-    PeerDropped,
-    /// Connection to self was detected.
-    SelfConnection,
-    /// Inbound connection limit reached.
-    ConnectionLimit,
-    /// Error with the underlying connection.
-    ConnectionError(Arc<std::io::Error>),
-    /// Error trying to decode incoming message.
-    DecodeError(Arc<encode::Error>),
-    /// Peer was forced to disconnect by external command.
-    Command,
-    /// Peer was disconnected for another reason.
-    Other(&'static str),
-}
-
-impl DisconnectReason {
-    /// Check whether the disconnect reason is transient, ie. may no longer be applicable
-    /// after some time.
-    pub fn is_transient(&self) -> bool {
-        matches!(
-            self,
-            Self::ConnectionLimit
-                | Self::PeerTimeout(_)
-                | Self::PeerHeight(_)
-                | Self::ConnectionError(_)
-        )
-    }
-}
-
-impl fmt::Display for DisconnectReason {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::PeerMisbehaving(reason) => write!(f, "peer misbehaving: {}", reason),
-            Self::PeerProtocolVersion(_) => write!(f, "peer protocol version mismatch"),
-            Self::PeerServices(_) => write!(f, "peer doesn't have the required services"),
-            Self::PeerHeight(_) => write!(f, "peer is too far behind"),
-            Self::PeerMagic(magic) => write!(f, "received message with invalid magic: {}", magic),
-            Self::PeerTimeout(s) => write!(f, "peer timed out: {:?}", s),
-            Self::PeerDropped => write!(f, "peer dropped"),
-            Self::PeerDisconnected => write!(f, "peer disconnected"),
-            Self::SelfConnection => write!(f, "detected self-connection"),
-            Self::ConnectionLimit => write!(f, "inbound connection limit reached"),
-            Self::ConnectionError(err) => write!(f, "connection error: {}", err),
-            Self::DecodeError(err) => write!(f, "message decode error: {}", err),
-            Self::Command => write!(f, "received external command"),
-            Self::Other(reason) => write!(f, "{}", reason),
-        }
     }
 }
 
@@ -255,18 +172,18 @@ impl Iterator for Drain {
 /// Ability to disconnect from peers.
 pub trait Disconnect {
     /// Disconnect from peer.
-    fn disconnect(&self, addr: net::SocketAddr, reason: DisconnectReason);
+    fn disconnect(&self, addr: net::SocketAddr, reason: super::DisconnectReason);
 }
 
 impl Disconnect for Outbox {
-    fn disconnect(&self, addr: net::SocketAddr, reason: DisconnectReason) {
+    fn disconnect(&self, addr: net::SocketAddr, reason: super::DisconnectReason) {
         debug!(target: self.target, "{}: Disconnecting: {}", addr, reason);
-        self.push(Io::Disconnect(addr, reason));
+        self.push(Io::Disconnect(addr, reason.into()));
     }
 }
 
 impl Disconnect for () {
-    fn disconnect(&self, _addr: net::SocketAddr, _reason: DisconnectReason) {}
+    fn disconnect(&self, _addr: net::SocketAddr, _reason: super::DisconnectReason) {}
 }
 
 /// The ability to be woken up in the future.

--- a/p2p/src/protocol/tests/simulator.rs
+++ b/p2p/src/protocol/tests/simulator.rs
@@ -37,7 +37,7 @@ pub enum Input {
         link: Link,
     },
     /// Disconnected from peer.
-    Disconnected(PeerId, DisconnectReason),
+    Disconnected(PeerId, nakamoto_net::DisconnectReason<DisconnectReason>),
     /// Received a message from a remote peer.
     Received(PeerId, Vec<u8>),
     /// Used to advance the state machine after some wall time has passed.
@@ -471,7 +471,7 @@ impl Simulation {
                                 remote,
                                 input: Input::Disconnected(
                                     remote,
-                                    DisconnectReason::ConnectionError(
+                                    nakamoto_net::DisconnectReason::ConnectionError(
                                         io::Error::from(io::ErrorKind::UnexpectedEof).into(),
                                     ),
                                 ),
@@ -529,7 +529,7 @@ impl Simulation {
                         remote: local_addr,
                         input: Input::Disconnected(
                             local_addr,
-                            DisconnectReason::ConnectionError(
+                            nakamoto_net::DisconnectReason::ConnectionError(
                                 io::Error::from(io::ErrorKind::UnexpectedEof).into(),
                             ),
                         ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,12 @@
 //! ```no_run
 //! use std::{net, thread};
 //!
-//! use nakamoto::client::{Publisher, Client, Config, Network, Services};
+//! use nakamoto::client::{Client, Config, Network, Services};
 //! use nakamoto::client::error::Error;
 //! use nakamoto::client::handle::Handle as _;
 //!
 //! /// The network reactor we're going to use.
-//! type Reactor = nakamoto::net::poll::Reactor<net::TcpStream, Publisher>;
+//! type Reactor = nakamoto::net::poll::Reactor<net::TcpStream>;
 //!
 //! /// Run the light-client.
 //! fn main() -> Result<(), Error> {

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -11,7 +11,7 @@ use nakamoto_common::bitcoin::Address;
 use nakamoto_client::handle::{self, Handle};
 use nakamoto_client::spv::utxos::Utxos;
 use nakamoto_client::Network;
-use nakamoto_client::{client, protocol, Client, Config, Event};
+use nakamoto_client::{protocol, Client, Config, Event};
 use nakamoto_common::block::Height;
 use nakamoto_common::network::Services;
 
@@ -95,7 +95,7 @@ impl<H: Handle> Wallet<H> {
 }
 
 /// The network reactor we're going to use.
-type Reactor = nakamoto_net_poll::Reactor<net::TcpStream, client::Publisher>;
+type Reactor = nakamoto_net_poll::Reactor<net::TcpStream>;
 
 /// Entry point for running the wallet.
 pub fn run(addresses: Vec<Address>, birth: Height) -> Result<(), Error> {


### PR DESCRIPTION
This will allow greater re-use of the reactor for other p2p
applications, as well as create a clearer separation between
protocol and i/o.