### PR TITLE
Parametrization of PeerId in Reactor API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ errors.err
 headers.db
 TODO
 NOTES
+.idea/

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -127,7 +127,7 @@ where
 }
 
 /// A light-client process.
-pub struct Client<R: Reactor> {
+pub struct Client<R: Reactor<net::SocketAddr>> {
     handle: chan::Sender<Command>,
     commands: chan::Receiver<Command>,
     events: event::Subscriber<protocol::Event>,
@@ -142,7 +142,7 @@ pub struct Client<R: Reactor> {
     reactor: R,
 }
 
-impl<R: Reactor> Client<R>
+impl<R: Reactor<net::SocketAddr>> Client<R>
 where
     Publisher<protocol::Event>: event::Publisher<protocol::Event>,
 {
@@ -345,7 +345,7 @@ where
     /// its own thread.
     pub fn run_with<P>(mut self, listen: Vec<net::SocketAddr>, protocol: P) -> Result<(), Error>
     where
-        P: nakamoto_net::Protocol<Event = protocol::Event, Command = Command>,
+        P: nakamoto_net::Protocol<net::SocketAddr, Event = protocol::Event, Command = Command>,
     {
         self.reactor.run::<P, Publisher<protocol::Event>>(
             &listen,

--- a/client/src/tests.rs
+++ b/client/src/tests.rs
@@ -22,7 +22,7 @@ use crate::client::{self, Client, Config};
 use crate::error;
 use crate::handle::Handle as _;
 
-type Reactor = nakamoto_net_poll::Reactor<net::TcpStream>;
+type Reactor = nakamoto_net_poll::Reactor<net::TcpStream, net::SocketAddr>;
 
 fn network(
     cfgs: &[Config],

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -1,5 +1,6 @@
 //! Peer-to-peer networking core types.
 #![allow(clippy::type_complexity)]
+use std::hash::Hash;
 use std::sync::Arc;
 use std::{fmt, io, net};
 
@@ -36,13 +37,13 @@ impl Link {
 
 /// Output of a state transition of the `Protocol` state machine.
 #[derive(Debug)]
-pub enum Io<E, D> {
+pub enum Io<E, D, Id: PeerId> {
     /// There are some bytes ready to be sent to a peer.
-    Write(net::SocketAddr, Vec<u8>),
+    Write(Id, Vec<u8>),
     /// Connect to a peer.
-    Connect(net::SocketAddr),
+    Connect(Id),
     /// Disconnect from a peer.
-    Disconnect(net::SocketAddr, D),
+    Disconnect(Id, D),
     /// Ask for a wakeup in a specified amount of time.
     Wakeup(LocalDuration),
     /// Emit an event.
@@ -82,10 +83,28 @@ impl<T: fmt::Display> fmt::Display for DisconnectReason<T> {
     }
 }
 
+/// Remote peer id, which must be convertible into a [`net::SocketAddr`]
+pub trait PeerId: Eq + Ord + Clone + Hash + fmt::Debug + From<net::SocketAddr> {
+    fn to_socket_addr(&self) -> net::SocketAddr;
+}
+
+impl<T> PeerId for T
+where
+    T: Eq + Ord + Clone + Hash + fmt::Debug,
+    T: Into<net::SocketAddr>,
+    T: From<net::SocketAddr>,
+{
+    fn to_socket_addr(&self) -> net::SocketAddr {
+        self.clone().into()
+    }
+}
+
 /// A protocol state-machine.
 ///
 /// Network protocols must implement this trait to be drivable by the reactor.
-pub trait Protocol: Iterator<Item = Io<Self::Event, Self::DisconnectReason>> {
+pub trait Protocol<Id: PeerId>:
+    Iterator<Item = Io<Self::Event, Self::DisconnectReason, Id>>
+{
     /// Events emitted by the protocol.
     type Event: fmt::Debug;
     /// Reason a peer was disconnected.
@@ -103,22 +122,18 @@ pub trait Protocol: Iterator<Item = Io<Self::Event, Self::DisconnectReason>> {
         // figures of children and girls and voices childish and girlish in the air." -JJ
     }
     /// Received bytes from a peer.
-    fn received_bytes(&mut self, addr: &net::SocketAddr, bytes: &[u8]);
+    fn received_bytes(&mut self, addr: &Id, bytes: &[u8]);
     /// Connection attempt underway.
     ///
     /// This is only encountered when an outgoing connection attempt is made,
     /// and is always called before [`Protocol::connected`].
     ///
     /// For incoming connections, [`Protocol::connected`] is called directly.
-    fn attempted(&mut self, addr: &net::SocketAddr);
+    fn attempted(&mut self, addr: &Id);
     /// New connection with a peer.
-    fn connected(&mut self, addr: net::SocketAddr, local_addr: &net::SocketAddr, link: Link);
+    fn connected(&mut self, addr: Id, local_addr: &net::SocketAddr, link: Link);
     /// Disconnected from peer.
-    fn disconnected(
-        &mut self,
-        addr: &net::SocketAddr,
-        reason: DisconnectReason<Self::DisconnectReason>,
-    );
+    fn disconnected(&mut self, addr: &Id, reason: DisconnectReason<Self::DisconnectReason>);
     /// An external command has been received.
     fn command(&mut self, cmd: Self::Command);
     /// Used to update the protocol's internal clock.
@@ -129,7 +144,9 @@ pub trait Protocol: Iterator<Item = Io<Self::Event, Self::DisconnectReason>> {
     /// Used to advance the state machine after some timer rings.
     fn wake(&mut self);
     /// Create a draining iterator over the protocol outputs.
-    fn drain(&mut self) -> Box<dyn Iterator<Item = Io<Self::Event, Self::DisconnectReason>> + '_> {
+    fn drain(
+        &mut self,
+    ) -> Box<dyn Iterator<Item = Io<Self::Event, Self::DisconnectReason, Id>> + '_> {
         Box::new(std::iter::from_fn(|| self.next()))
     }
 }
@@ -142,7 +159,7 @@ pub trait Waker: Send + Sync + Clone {
 }
 
 /// Any network reactor that can drive the light-client protocol.
-pub trait Reactor {
+pub trait Reactor<Id: PeerId> {
     /// The type of waker this reactor uses.
     type Waker: Waker;
 
@@ -164,7 +181,7 @@ pub trait Reactor {
         commands: chan::Receiver<P::Command>,
     ) -> Result<(), error::Error>
     where
-        P: Protocol,
+        P: Protocol<Id>,
         P::DisconnectReason: Into<DisconnectReason<P::DisconnectReason>>,
         E: Publisher<P::Event>;
 

--- a/net/src/simulator.rs
+++ b/net/src/simulator.rs
@@ -18,12 +18,12 @@ pub const MAX_EVENTS: usize = 2048;
 
 /// Identifier for a simulated node/peer.
 /// The simulator requires each peer to have a distinct IP address.
-type NodeId = std::net::IpAddr;
+type NodeId = net::IpAddr;
 
 /// A simulated peer. Protocol instances have to be wrapped in this type to be simulated.
 pub trait Peer<P>: Deref<Target = P> + DerefMut<Target = P> + 'static
 where
-    P: Protocol,
+    P: Protocol<net::SocketAddr>,
 {
     /// Initialize the peer. This should at minimum initialize the protocol with the
     /// current time.
@@ -157,7 +157,7 @@ impl Default for Options {
 /// A peer-to-peer node simulation.
 pub struct Simulation<T>
 where
-    T: Protocol,
+    T: Protocol<net::SocketAddr>,
 {
     /// Inbox of inputs to be delivered by the simulation.
     inbox: Inbox<T::DisconnectReason>,
@@ -185,7 +185,7 @@ where
 
 impl<T> Simulation<T>
 where
-    T: Protocol + 'static,
+    T: Protocol<net::SocketAddr> + 'static,
     T::DisconnectReason: Clone + Into<DisconnectReason<T::DisconnectReason>>,
 {
     /// Create a new simulation.
@@ -404,7 +404,11 @@ where
     }
 
     /// Process a protocol output event from a node.
-    pub fn schedule(&mut self, node: &NodeId, out: Io<T::Event, T::DisconnectReason>) {
+    pub fn schedule(
+        &mut self,
+        node: &NodeId,
+        out: Io<T::Event, T::DisconnectReason, net::SocketAddr>,
+    ) {
         let node = *node;
 
         match out {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -13,7 +13,7 @@ use nakamoto_client::protocol;
 pub mod logger;
 
 /// The network reactor we're going to use.
-type Reactor = nakamoto_net_poll::Reactor<net::TcpStream>;
+type Reactor = nakamoto_net_poll::Reactor<net::TcpStream, net::SocketAddr>;
 
 /// Run the light-client. Takes an initial list of peers to connect to, a list of listen addresses,
 /// the client root and the Bitcoin network to connect to.

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -823,8 +823,8 @@ impl<T: BlockTree, F: Filters, P: peer::Store, C: AdjustedClock<PeerId>> Iterato
     }
 }
 
-impl<T: BlockTree, F: Filters, P: peer::Store, C: AdjustedClock<PeerId>> nakamoto_net::Protocol
-    for Protocol<T, F, P, C>
+impl<T: BlockTree, F: Filters, P: peer::Store, C: AdjustedClock<PeerId>>
+    nakamoto_net::Protocol<net::SocketAddr> for Protocol<T, F, P, C>
 {
     type Event = Event;
     type DisconnectReason = DisconnectReason;

--- a/p2p/src/protocol/output.rs
+++ b/p2p/src/protocol/output.rs
@@ -30,7 +30,7 @@ use super::network::Network;
 use super::{addrmgr, cbfmgr, invmgr, peermgr, pingmgr, syncmgr, Locators};
 
 /// Output of a state transition of the `Protocol` state machine.
-pub type Io = nakamoto_net::Io<Event, super::DisconnectReason>;
+pub type Io = nakamoto_net::Io<Event, super::DisconnectReason, net::SocketAddr>;
 
 impl From<Event> for Io {
     fn from(event: Event) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! use nakamoto::client::handle::Handle as _;
 //!
 //! /// The network reactor we're going to use.
-//! type Reactor = nakamoto::net::poll::Reactor<net::TcpStream>;
+//! type Reactor = nakamoto::net::poll::Reactor<net::TcpStream, net::SocketAddr>;
 //!
 //! /// Run the light-client.
 //! fn main() -> Result<(), Error> {

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -95,7 +95,7 @@ impl<H: Handle> Wallet<H> {
 }
 
 /// The network reactor we're going to use.
-type Reactor = nakamoto_net_poll::Reactor<net::TcpStream>;
+type Reactor = nakamoto_net_poll::Reactor<net::TcpStream, net::SocketAddr>;
 
 /// Entry point for running the wallet.
 pub fn run(addresses: Vec<Address>, birth: Height) -> Result<(), Error> {


### PR DESCRIPTION
Required to support arbitrary remote peer types, operating not just as sockets, but through proxy (which will always have the same address for all peers), like SOCKS5-based proxies (used in Tor, I2P, Nym etc)