### PR TITLE
Update rust-bitcoin to 0.29.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,15 +59,15 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bech32"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bitcoin"
-version = "0.28.1"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05bba324e6baf655b882df672453dbbc527bc938cadd27750ae510aaccc3a66a"
+checksum = "9cb36de3b18ad25f396f9168302e36fb7e1e8923298ab3127da252d288d5af9d"
 dependencies = [
  "bech32",
  "bitcoin_hashes",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006cc91e1a1d99819bc5b8214be3555c1f0611b169f527a1fdc54ed1f2b745b0"
+checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 
 [[package]]
 name = "bitflags"
@@ -525,18 +525,19 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.22.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26947345339603ae8395f68e2f3d85a6b0a8ddfe6315818e80b8504415099db0"
+checksum = "b7649a0b3ffb32636e60c7ce0d70511eda9c52c658cd0634e194d5a19943aeff"
 dependencies = [
+ "bitcoin_hashes",
  "secp256k1-sys",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152e20a0fd0519390fc43ab404663af8a0b794273d2a91d60ad4a39f13ffe110"
+checksum = "7058dc8eaf3f2810d7828680320acda0b25a288f6d288e19278e249bbf74226b"
 dependencies = [
  "cc",
 ]

--- a/chain/src/block/store/io.rs
+++ b/chain/src/block/store/io.rs
@@ -33,7 +33,7 @@ fn get<H: Decodable, S: Seek + Read>(mut stream: S, ix: u64) -> Result<H, Error>
     stream.seek(io::SeekFrom::Start(ix * size as u64))?;
     stream.read_exact(&mut buf)?;
 
-    H::consensus_decode(&buf[..]).map_err(Error::from)
+    H::consensus_decode(&mut buf.as_slice()).map_err(Error::from)
 }
 
 /// An iterator over block headers in a file.
@@ -196,6 +196,10 @@ impl<H: 'static + Copy + Encodable + Decodable> Store for File<H> {
 mod test {
     use std::{io, iter};
 
+    use nakamoto_common::bitcoin::TxMerkleNode;
+    use nakamoto_common::bitcoin_hashes::Hash;
+    use nakamoto_common::block::BlockHash;
+
     use super::{Error, File, Height, Store};
     use crate::block::BlockHeader;
 
@@ -205,8 +209,8 @@ mod test {
         let tmp = tempfile::tempdir().unwrap();
         let genesis = BlockHeader {
             version: 1,
-            prev_blockhash: Default::default(),
-            merkle_root: Default::default(),
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
             bits: 0x2ffffff,
             time: 39123818,
             nonce: 0,
@@ -222,7 +226,7 @@ mod test {
         let header = BlockHeader {
             version: 1,
             prev_blockhash: store.genesis.block_hash(),
-            merkle_root: Default::default(),
+            merkle_root: TxMerkleNode::all_zeros(),
             bits: 0x2ffffff,
             time: 1842918273,
             nonce: 312143,
@@ -255,7 +259,7 @@ mod test {
         let header = BlockHeader {
             version: 1,
             prev_blockhash: store.genesis().block_hash(),
-            merkle_root: Default::default(),
+            merkle_root: TxMerkleNode::all_zeros(),
             bits: 0x2ffffff,
             time: 1842918273,
             nonce: 0,
@@ -319,7 +323,7 @@ mod test {
         let header = BlockHeader {
             version: 1,
             prev_blockhash: store.genesis().block_hash(),
-            merkle_root: Default::default(),
+            merkle_root: TxMerkleNode::all_zeros(),
             bits: 0x2ffffff,
             time: 1842918273,
             nonce: 0,
@@ -351,15 +355,15 @@ mod test {
             BlockHeader {
                 version: 1,
                 prev_blockhash: store.genesis().block_hash(),
-                merkle_root: Default::default(),
+                merkle_root: TxMerkleNode::all_zeros(),
                 bits: 0x2ffffff,
                 time: 1842918273,
                 nonce: 312143,
             },
             BlockHeader {
                 version: 1,
-                prev_blockhash: Default::default(),
-                merkle_root: Default::default(),
+                prev_blockhash: BlockHash::all_zeros(),
+                merkle_root: TxMerkleNode::all_zeros(),
                 bits: 0x1ffffff,
                 time: 1842918920,
                 nonce: 913716378,

--- a/client/src/spv/tests.rs
+++ b/client/src/spv/tests.rs
@@ -39,6 +39,7 @@
 #![allow(unused_imports)]
 use std::{io, iter, net, thread};
 
+use nakamoto_common::bitcoin_hashes::Hash;
 use quickcheck::TestResult;
 use quickcheck_macros::quickcheck;
 
@@ -332,20 +333,20 @@ fn test_tx_status_ordering() {
             peer: ([0, 0, 0, 0], 0).into()
         } < TxStatus::Confirmed {
             height: 0,
-            block: BlockHash::default(),
+            block: BlockHash::all_zeros(),
         }
     );
     assert!(
         TxStatus::Confirmed {
             height: 0,
-            block: BlockHash::default(),
+            block: BlockHash::all_zeros(),
         } < TxStatus::Reverted
     );
     assert!(
         TxStatus::Reverted
             < TxStatus::Stale {
-                replaced_by: Default::default(),
-                block: BlockHash::default()
+                replaced_by: Txid::all_zeros(),
+                block: BlockHash::all_zeros()
             }
     );
 }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2021"
 
 [dependencies]
 nakamoto-net = { version = "0.3.0", path = "../net" }
-bitcoin = "0.28.0"
-bitcoin_hashes = "0.10.0"
+bitcoin = "0.29.1"
+bitcoin_hashes = "0.11.0"
 thiserror = "1.0"
 fastrand = "1.3.5"
 nonempty = "0.7"

--- a/common/src/block/filter.rs
+++ b/common/src/block/filter.rs
@@ -3,6 +3,7 @@
 
 use std::ops::RangeInclusive;
 
+use bitcoin_hashes::Hash;
 use thiserror::Error;
 
 pub use bitcoin::hash_types::{FilterHash, FilterHeader};
@@ -32,7 +33,7 @@ impl Genesis for FilterHeader {
     /// ```
     fn genesis(network: Network) -> Self {
         let filter = BlockFilter::genesis(network);
-        filter.filter_header(&FilterHeader::default())
+        filter.filter_header(&FilterHeader::all_zeros())
     }
 }
 
@@ -64,7 +65,7 @@ pub trait Filters {
     fn get_prev_header(&self, height: Height) -> Option<FilterHeader> {
         if height == 0 {
             // If the start height is `0` (genesis), we return the zero hash as the parent.
-            Some(FilterHeader::default())
+            Some(FilterHeader::all_zeros())
         } else {
             self.get_header(height - 1).map(|(_, h)| h)
         }

--- a/common/src/network.rs
+++ b/common/src/network.rs
@@ -3,8 +3,8 @@
 use bitcoin::blockdata::block::{Block, BlockHeader};
 use bitcoin::consensus::params::Params;
 use bitcoin::hash_types::BlockHash;
+use bitcoin::hashes::hex::FromHex;
 use bitcoin::network::constants::ServiceFlags;
-use bitcoin_hashes::hex::FromHex;
 
 use bitcoin_hashes::sha256d;
 
@@ -176,7 +176,7 @@ impl Network {
             Self::Regtest => genesis::REGTEST,
             Self::Signet => genesis::SIGNET,
         };
-        BlockHash::from(
+        BlockHash::from_hash(
             sha256d::Hash::from_slice(hash)
                 .expect("the genesis hash has the right number of bytes"),
         )

--- a/common/src/p2p/peer.rs
+++ b/common/src/p2p/peer.rs
@@ -232,7 +232,7 @@ impl KnownAddress {
         let ip = &self.addr.address;
         let port = &self.addr.port;
         let address = net::SocketAddr::from((*ip, *port)).to_string();
-        let services = self.addr.services.as_u64();
+        let services = self.addr.services.to_u64();
 
         let mut obj = Object::new();
 

--- a/p2p/src/fsm/syncmgr.rs
+++ b/p2p/src/fsm/syncmgr.rs
@@ -5,6 +5,7 @@ use nakamoto_common::bitcoin::consensus::params::Params;
 use nakamoto_common::bitcoin::network::constants::ServiceFlags;
 use nakamoto_common::bitcoin::network::message_blockdata::Inventory;
 
+use nakamoto_common::bitcoin_hashes::Hash;
 use nakamoto_common::block::store;
 use nakamoto_common::block::time::{Clock, LocalDuration, LocalTime};
 use nakamoto_common::block::tree::{BlockReader, BlockTree, Error, ImportResult};
@@ -393,7 +394,7 @@ impl<U: Wakeup + Disconnect + Wire<Event>, C: Clock> SyncManager<U, C> {
                     self.broadcast_tip(&tip, tree);
                     self.sync(tree);
                 } else {
-                    let locators = (vec![tip], BlockHash::default());
+                    let locators = (vec![tip], BlockHash::all_zeros());
                     let timeout = self.config.request_timeout;
 
                     self.request(*from, locators, timeout, OnTimeout::Disconnect);
@@ -609,7 +610,7 @@ impl<U: Wakeup + Disconnect + Wire<Event>, C: Clock> SyncManager<U, C> {
     fn register(&mut self, socket: Socket, height: Height, preferred: bool, link: Link) {
         let last_active = None;
         let last_asked = None;
-        let tip = BlockHash::default();
+        let tip = BlockHash::all_zeros();
 
         self.peers.insert(
             socket.addr,
@@ -706,7 +707,7 @@ impl<U: Wakeup + Disconnect + Wire<Event>, C: Clock> SyncManager<U, C> {
 
         // ... It looks like we're out of sync ...
 
-        let locators = (tree.locator_hashes(tree.height()), BlockHash::default());
+        let locators = (tree.locator_hashes(tree.height()), BlockHash::all_zeros());
 
         // If we're already fetching these headers, just wait.
         if self.syncing(&locators) {
@@ -766,7 +767,7 @@ impl<U: Wakeup + Disconnect + Wire<Event>, C: Clock> SyncManager<U, C> {
         for addr in addrs {
             self.request(
                 addr,
-                (locators.clone(), BlockHash::default()),
+                (locators.clone(), BlockHash::all_zeros()),
                 self.config.request_timeout,
                 OnTimeout::Ignore,
             );

--- a/test/src/block/cache/model.rs
+++ b/test/src/block/cache/model.rs
@@ -3,6 +3,7 @@
 
 use std::ops::RangeInclusive;
 
+use nakamoto_common::bitcoin_hashes::Hash;
 use nakamoto_common::block::filter::{self, BlockFilter, FilterHash, FilterHeader, Filters};
 use nakamoto_common::block::iter::Iter;
 use nakamoto_common::block::tree::{BlockReader, BlockTree, Branch, Error, ImportResult};
@@ -241,7 +242,7 @@ pub struct FilterCache {
 impl FilterCache {
     pub fn new(genesis: FilterHeader) -> Self {
         Self {
-            headers: NonEmpty::new((FilterHash::default(), genesis)),
+            headers: NonEmpty::new((FilterHash::all_zeros(), genesis)),
             filters: BTreeMap::new(),
         }
     }

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -22,7 +22,7 @@ lazy_static! {
         let mut headers = NonEmpty::new(genesis);
 
         while f.read_exact(&mut buf).is_ok() {
-            let header = BlockHeader::consensus_decode(&buf[..]).unwrap();
+            let header = BlockHeader::consensus_decode(&mut buf.as_slice()).unwrap();
             headers.push(header);
         }
         headers


### PR DESCRIPTION
This PR updates `rust-bitcoin` to `0.29.1`. This release links to a new version of the secp256k1 library, so this update is a prerequisite for being able to use Nakamoto in projects that use the above mentioned version of `rust-bitcoin` (there is a Cargo limitation that prevents having such a dependency tree that different crates link to different versions of the same native library).

I didn't bump any version numbers as the author may want to get multiple changes in before creating a release or bumping. If there's a specific version that should be used here, please let me know and I'll update `Cargo.toml` for each subcrate.