### PR TITLE
Improve doc comments and type names for nakamoto_net library

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -372,7 +372,7 @@ where
     where
         P: nakamoto_net::PeerService<Notification = fsm::Event, Command = Command>,
     {
-        self.reactor.run::<P, Publisher<fsm::Event>>(
+        self.reactor.run(
             &listen,
             protocol,
             self.publisher,

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -370,7 +370,7 @@ where
     /// its own thread.
     pub fn run_with<P>(mut self, listen: Vec<net::SocketAddr>, protocol: P) -> Result<(), Error>
     where
-        P: nakamoto_net::Service<Event = fsm::Event, Command = Command>,
+        P: nakamoto_net::PeerService<Event = fsm::Event, Command = Command>,
     {
         self.reactor.run::<P, Publisher<fsm::Event>>(
             &listen,

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -34,7 +34,7 @@ use nakamoto_p2p::fsm;
 
 pub use nakamoto_net::event;
 pub use nakamoto_net::{Reactor, Waker};
-pub use nakamoto_p2p::fsm::{Command, CommandError, Hooks, Limits, ConnDirection, Peer};
+pub use nakamoto_p2p::fsm::{Command, CommandError, ConnDirection, Hooks, Limits, Peer};
 
 pub use crate::error::Error;
 pub use crate::event::{Event, Loading};
@@ -370,7 +370,7 @@ where
     /// its own thread.
     pub fn run_with<P>(mut self, listen: Vec<net::SocketAddr>, protocol: P) -> Result<(), Error>
     where
-        P: nakamoto_net::PeerService<Notification= fsm::Event, Command = Command>,
+        P: nakamoto_net::PeerService<Notification = fsm::Event, Command = Command>,
     {
         self.reactor.run::<P, Publisher<fsm::Event>>(
             &listen,

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -34,7 +34,7 @@ use nakamoto_p2p::fsm;
 
 pub use nakamoto_net::event;
 pub use nakamoto_net::{Reactor, Waker};
-pub use nakamoto_p2p::fsm::{Command, CommandError, Hooks, Limits, Link, Peer};
+pub use nakamoto_p2p::fsm::{Command, CommandError, Hooks, Limits, ConnDirection, Peer};
 
 pub use crate::error::Error;
 pub use crate::event::{Event, Loading};
@@ -370,7 +370,7 @@ where
     /// its own thread.
     pub fn run_with<P>(mut self, listen: Vec<net::SocketAddr>, protocol: P) -> Result<(), Error>
     where
-        P: nakamoto_net::PeerService<Event = fsm::Event, Command = Command>,
+        P: nakamoto_net::PeerService<Notification= fsm::Event, Command = Command>,
     {
         self.reactor.run::<P, Publisher<fsm::Event>>(
             &listen,
@@ -557,7 +557,7 @@ impl<W: Waker> handle::Handle for Handle<W> {
         Ok(receive.recv()?)
     }
 
-    fn connect(&self, addr: net::SocketAddr) -> Result<Link, handle::Error> {
+    fn connect(&self, addr: net::SocketAddr) -> Result<ConnDirection, handle::Error> {
         let events = self.events();
         self.command(Command::Connect(addr))?;
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -372,12 +372,8 @@ where
     where
         P: nakamoto_net::PeerService<Notification = fsm::Event, Command = Command>,
     {
-        self.reactor.run(
-            &listen,
-            protocol,
-            self.publisher,
-            self.commands,
-        )?;
+        self.reactor
+            .run(&listen, protocol, self.publisher, self.commands)?;
 
         Ok(())
     }

--- a/client/src/event.rs
+++ b/client/src/event.rs
@@ -9,7 +9,7 @@ use nakamoto_common::block::{BlockHash, BlockHeader, Height};
 use nakamoto_net::DisconnectReason;
 use nakamoto_p2p::fsm;
 use nakamoto_p2p::fsm::fees::FeeEstimate;
-use nakamoto_p2p::fsm::{Link, PeerId};
+use nakamoto_p2p::fsm::{ConnDirection, PeerId};
 
 use crate::spv::TxStatus;
 
@@ -70,7 +70,7 @@ pub enum Event {
         /// Peer address.
         addr: PeerId,
         /// Connection link.
-        link: Link,
+        link: ConnDirection,
     },
     /// Peer disconnected after successful connection.
     PeerDisconnected {
@@ -91,7 +91,7 @@ pub enum Event {
         /// Peer address.
         addr: PeerId,
         /// Connection link.
-        link: Link,
+        link: ConnDirection,
         /// Peer services.
         services: ServiceFlags,
         /// Peer height.

--- a/client/src/handle.rs
+++ b/client/src/handle.rs
@@ -15,7 +15,7 @@ use nakamoto_common::block::filter::BlockFilter;
 use nakamoto_common::block::tree::{BlockReader, ImportResult};
 use nakamoto_common::block::{self, Block, BlockHash, BlockHeader, Height, Transaction};
 use nakamoto_common::nonempty::NonEmpty;
-use nakamoto_p2p::fsm::Link;
+use nakamoto_p2p::fsm::ConnDirection;
 use nakamoto_p2p::fsm::{self, Command, CommandError, GetFiltersError, Peer};
 
 use crate::client::{Event, Loading};
@@ -135,7 +135,7 @@ pub trait Handle: Sized + Send + Sync + Clone {
     /// peer or nothing if no peer was available.
     fn query(&self, msg: NetworkMessage) -> Result<Option<net::SocketAddr>, Error>;
     /// Connect to the designated peer address.
-    fn connect(&self, addr: net::SocketAddr) -> Result<Link, Error>;
+    fn connect(&self, addr: net::SocketAddr) -> Result<ConnDirection, Error>;
     /// Disconnect from the designated peer address.
     fn disconnect(&self, addr: net::SocketAddr) -> Result<(), Error>;
     /// Submit a transaction to the network.

--- a/client/src/service.rs
+++ b/client/src/service.rs
@@ -80,7 +80,7 @@ where
 {
     type PeerMessage = [u8];
     type Notification = p2p::Event;
-    type DisconnectSubreason = p2p::DisconnectReason;
+    type DisconnectDemand = p2p::DisconnectReason;
 
     fn initialize(&mut self, time: LocalTime) {
         self.machine.initialize(time);
@@ -90,8 +90,8 @@ where
         self.machine.tick(local_time);
     }
 
-    fn wake(&mut self) {
-        self.machine.wake();
+    fn on_timer(&mut self) {
+        self.machine.on_timer();
     }
 
     fn received(&mut self, addr: &net::SocketAddr, bytes: Cow<[u8]>) {
@@ -130,7 +130,7 @@ where
     fn disconnected(
         &mut self,
         addr: &net::SocketAddr,
-        reason: DisconnectReason<Self::DisconnectSubreason>,
+        reason: DisconnectReason<Self::DisconnectDemand>,
     ) {
         self.inboxes.remove(addr);
         self.machine.disconnected(addr, reason)

--- a/client/src/service.rs
+++ b/client/src/service.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use nakamoto_chain::BlockTree;
 use nakamoto_common::bitcoin::consensus::Encodable;
 use nakamoto_common::block::time::{AdjustedClock, LocalTime};
-use nakamoto_net::{DisconnectReason, ReactorDispatch, ConnDirection, PeerProtocol};
+use nakamoto_net::{ConnDirection, DisconnectReason, PeerProtocol, ReactorDispatch};
 use nakamoto_p2p as p2p;
 
 use crate::client::Config;
@@ -122,7 +122,12 @@ where
         self.machine.attempted(addr)
     }
 
-    fn connected(&mut self, addr: net::SocketAddr, local_addr: &net::SocketAddr, link: ConnDirection) {
+    fn connected(
+        &mut self,
+        addr: net::SocketAddr,
+        local_addr: &net::SocketAddr,
+        link: ConnDirection,
+    ) {
         self.inboxes.insert(addr, p2p::stream::Decoder::new(1024));
         self.machine.connected(addr, local_addr, link)
     }
@@ -151,9 +156,13 @@ impl<T, F, P, C> Iterator for Service<T, F, P, C> {
 
                 Some(ReactorDispatch::SendPeer(addr, buf))
             }
-            Some(ReactorDispatch::NotifySubscribers(e)) => Some(ReactorDispatch::NotifySubscribers(e)),
+            Some(ReactorDispatch::NotifySubscribers(e)) => {
+                Some(ReactorDispatch::NotifySubscribers(e))
+            }
             Some(ReactorDispatch::ConnectPeer(a)) => Some(ReactorDispatch::ConnectPeer(a)),
-            Some(ReactorDispatch::DisconnectPeer(a, r)) => Some(ReactorDispatch::DisconnectPeer(a, r)),
+            Some(ReactorDispatch::DisconnectPeer(a, r)) => {
+                Some(ReactorDispatch::DisconnectPeer(a, r))
+            }
             Some(ReactorDispatch::SetTimer(d)) => Some(ReactorDispatch::SetTimer(d)),
 
             None => None,

--- a/client/src/service.rs
+++ b/client/src/service.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use nakamoto_chain::BlockTree;
 use nakamoto_common::bitcoin::consensus::Encodable;
 use nakamoto_common::block::time::{AdjustedClock, LocalTime};
-use nakamoto_net::{DisconnectReason, ReactorDispatch, Link, StateMachine};
+use nakamoto_net::{DisconnectReason, ReactorDispatch, Link, PeerProtocol};
 use nakamoto_p2p as p2p;
 
 use crate::client::Config;
@@ -56,7 +56,7 @@ impl<T: BlockTree, F: filter::Filters, P: peer::Store, C: AdjustedClock<net::Soc
     }
 }
 
-impl<T, F, P, C> nakamoto_net::Service for Service<T, F, P, C>
+impl<T, F, P, C> nakamoto_net::PeerService for Service<T, F, P, C>
 where
     T: BlockTree,
     F: filter::Filters,
@@ -71,7 +71,7 @@ where
     }
 }
 
-impl<T, F, P, C> StateMachine for Service<T, F, P, C>
+impl<T, F, P, C> PeerProtocol for Service<T, F, P, C>
 where
     T: BlockTree,
     F: filter::Filters,

--- a/client/src/spv/tests.rs
+++ b/client/src/spv/tests.rs
@@ -48,7 +48,7 @@ use nakamoto_common::bitcoin::OutPoint;
 use nakamoto_common::block::time::Clock as _;
 use nakamoto_common::network::Network;
 use nakamoto_common::nonempty::NonEmpty;
-use nakamoto_net::{DisconnectReason, Link, LocalTime, PeerService as _, PeerProtocol as _};
+use nakamoto_net::{DisconnectReason, ConnDirection, LocalTime, PeerService as _, PeerProtocol as _};
 use nakamoto_test::assert_matches;
 use nakamoto_test::block::gen;
 use nakamoto_test::logger;
@@ -86,13 +86,13 @@ fn test_peer_connected_disconnected() {
 
     client
         .protocol
-        .connected(remote, &local_addr, Link::Inbound);
+        .connected(remote, &local_addr, ConnDirection::Inbound);
     client.step();
 
     assert_matches!(
         events.try_recv(),
         Ok(Event::PeerConnected { addr, link, .. })
-        if addr == remote && link == Link::Inbound
+        if addr == remote && link == ConnDirection::Inbound
     );
 
     client.protocol.disconnected(
@@ -166,7 +166,7 @@ fn test_peer_height_updated() {
 
     client
         .protocol
-        .connected(remote, &local_addr, Link::Inbound);
+        .connected(remote, &local_addr, ConnDirection::Inbound);
     client.received(&remote, version(42));
     client.received(&remote, NetworkMessage::Verack);
     client.step();
@@ -180,7 +180,7 @@ fn test_peer_height_updated() {
 
     client
         .protocol
-        .connected(remote, &local_addr, Link::Inbound);
+        .connected(remote, &local_addr, ConnDirection::Inbound);
     client.received(&remote, version(43));
     client.received(&remote, NetworkMessage::Verack);
     client.step();
@@ -208,7 +208,7 @@ fn test_peer_negotiated() {
 
     client
         .protocol
-        .connected(remote, &local_addr, Link::Inbound);
+        .connected(remote, &local_addr, ConnDirection::Inbound);
     client.step();
 
     let version = NetworkMessage::Version(VersionMessage {

--- a/client/src/spv/tests.rs
+++ b/client/src/spv/tests.rs
@@ -48,7 +48,9 @@ use nakamoto_common::bitcoin::OutPoint;
 use nakamoto_common::block::time::Clock as _;
 use nakamoto_common::network::Network;
 use nakamoto_common::nonempty::NonEmpty;
-use nakamoto_net::{DisconnectReason, ConnDirection, LocalTime, PeerService as _, PeerProtocol as _};
+use nakamoto_net::{
+    ConnDirection, DisconnectReason, LocalTime, PeerProtocol as _, PeerService as _,
+};
 use nakamoto_test::assert_matches;
 use nakamoto_test::block::gen;
 use nakamoto_test::logger;

--- a/client/src/spv/tests.rs
+++ b/client/src/spv/tests.rs
@@ -48,7 +48,7 @@ use nakamoto_common::bitcoin::OutPoint;
 use nakamoto_common::block::time::Clock as _;
 use nakamoto_common::network::Network;
 use nakamoto_common::nonempty::NonEmpty;
-use nakamoto_net::{DisconnectReason, Link, LocalTime, Service as _, StateMachine as _};
+use nakamoto_net::{DisconnectReason, Link, LocalTime, PeerService as _, PeerProtocol as _};
 use nakamoto_test::assert_matches;
 use nakamoto_test::block::gen;
 use nakamoto_test::logger;

--- a/client/src/tests/mock.rs
+++ b/client/src/tests/mock.rs
@@ -20,7 +20,7 @@ use nakamoto_common::p2p::peer::KnownAddress;
 use nakamoto_test::block::cache::model;
 
 use nakamoto_net::event;
-use nakamoto_net::StateMachine as _;
+use nakamoto_net::PeerProtocol as _;
 use nakamoto_p2p::fsm;
 use nakamoto_p2p::fsm::Command;
 use nakamoto_p2p::fsm::Link;

--- a/client/src/tests/mock.rs
+++ b/client/src/tests/mock.rs
@@ -23,7 +23,7 @@ use nakamoto_net::event;
 use nakamoto_net::PeerProtocol as _;
 use nakamoto_p2p::fsm;
 use nakamoto_p2p::fsm::Command;
-use nakamoto_p2p::fsm::Link;
+use nakamoto_p2p::fsm::ConnDirection;
 use nakamoto_p2p::fsm::Peer;
 use nakamoto_p2p::fsm::StateMachine;
 
@@ -90,7 +90,7 @@ impl Client {
 
         for out in self.protocol.drain() {
             match out {
-                fsm::Io::Event(event) => {
+                fsm::Io::NotifySubscribers(event) => {
                     self.subscriber.broadcast(event.clone());
                     self.events.send(event).ok();
                 }
@@ -213,7 +213,7 @@ impl Handle for TestHandle {
         unimplemented!()
     }
 
-    fn connect(&self, _addr: net::SocketAddr) -> Result<Link, handle::Error> {
+    fn connect(&self, _addr: net::SocketAddr) -> Result<ConnDirection, handle::Error> {
         unimplemented!()
     }
 

--- a/net/poll/src/reactor.rs
+++ b/net/poll/src/reactor.rs
@@ -123,17 +123,13 @@ impl<Id: PeerId> nakamoto_net::Reactor<Id> for Reactor<net::TcpStream, Id> {
     }
 
     /// Run the given service with the reactor.
-    fn run<S, E>(
+    fn run<N, C>(
         &mut self,
         listen_addrs: &[net::SocketAddr],
-        mut service: S,
-        mut publisher: E,
-        commands: chan::Receiver<S::Command>,
+        mut service: impl PeerService<Id, Notification = N, Command = C>,
+        mut publisher: impl Publisher<N>,
+        commands: chan::Receiver<C>,
     ) -> Result<(), Error>
-    where
-        S: PeerService<Id>,
-        S::DisconnectDemand: Into<DisconnectReason<S::DisconnectDemand>>,
-        E: Publisher<S::Notification>,
     {
         let listener = if listen_addrs.is_empty() {
             None
@@ -285,7 +281,6 @@ impl<Id: PeerId> Reactor<net::TcpStream, Id> {
     where
         S: PeerService<Id>,
         E: Publisher<S::Notification>,
-        S::DisconnectDemand: Into<DisconnectReason<S::DisconnectDemand>>,
     {
         // Note that there may be messages destined for a peer that has since been
         // disconnected.

--- a/net/poll/src/reactor.rs
+++ b/net/poll/src/reactor.rs
@@ -129,8 +129,7 @@ impl<Id: PeerId> nakamoto_net::Reactor<Id> for Reactor<net::TcpStream, Id> {
         mut service: impl PeerService<Id, Notification = N, Command = C>,
         mut publisher: impl Publisher<N>,
         commands: chan::Receiver<C>,
-    ) -> Result<(), Error>
-    {
+    ) -> Result<(), Error> {
         let listener = if listen_addrs.is_empty() {
             None
         } else {

--- a/net/poll/src/reactor.rs
+++ b/net/poll/src/reactor.rs
@@ -4,8 +4,8 @@ use crossbeam_channel as chan;
 use nakamoto_net::error::Error;
 use nakamoto_net::event::Publisher;
 use nakamoto_net::time::{LocalDuration, LocalTime};
-use nakamoto_net::{DisconnectReason, ReactorDispatch, PeerId};
 use nakamoto_net::{ConnDirection, PeerService};
+use nakamoto_net::{DisconnectReason, PeerId, ReactorDispatch};
 
 use log::*;
 

--- a/net/poll/src/reactor.rs
+++ b/net/poll/src/reactor.rs
@@ -83,7 +83,7 @@ impl<R: Write + Read + AsRawFd, Id: PeerId> Reactor<R, Id> {
     fn unregister_peer<S>(
         &mut self,
         addr: Id,
-        reason: DisconnectReason<S::DisconnectSubreason>,
+        reason: DisconnectReason<S::DisconnectDemand>,
         service: &mut S,
     ) where
         S: PeerService<Id>,
@@ -132,7 +132,7 @@ impl<Id: PeerId> nakamoto_net::Reactor<Id> for Reactor<net::TcpStream, Id> {
     ) -> Result<(), Error>
     where
         S: PeerService<Id>,
-        S::DisconnectSubreason: Into<DisconnectReason<S::DisconnectSubreason>>,
+        S::DisconnectDemand: Into<DisconnectReason<S::DisconnectDemand>>,
         E: Publisher<S::Notification>,
     {
         let listener = if listen_addrs.is_empty() {
@@ -262,7 +262,7 @@ impl<Id: PeerId> nakamoto_net::Reactor<Id> for Reactor<net::TcpStream, Id> {
 
                     if !timeouts.is_empty() {
                         timeouts.clear();
-                        service.wake();
+                        service.on_timer();
                     }
                 }
                 Err(err) => return Err(err.into()),
@@ -285,7 +285,7 @@ impl<Id: PeerId> Reactor<net::TcpStream, Id> {
     where
         S: PeerService<Id>,
         E: Publisher<S::Notification>,
-        S::DisconnectSubreason: Into<DisconnectReason<S::DisconnectSubreason>>,
+        S::DisconnectDemand: Into<DisconnectReason<S::DisconnectDemand>>,
     {
         // Note that there may be messages destined for a peer that has since been
         // disconnected.

--- a/net/poll/src/reactor.rs
+++ b/net/poll/src/reactor.rs
@@ -5,7 +5,7 @@ use nakamoto_net::error::Error;
 use nakamoto_net::event::Publisher;
 use nakamoto_net::time::{LocalDuration, LocalTime};
 use nakamoto_net::{DisconnectReason, ReactorDispatch, PeerId};
-use nakamoto_net::{Link, Service};
+use nakamoto_net::{Link, PeerService};
 
 use log::*;
 
@@ -86,7 +86,7 @@ impl<R: Write + Read + AsRawFd, Id: PeerId> Reactor<R, Id> {
         reason: DisconnectReason<S::DisconnectSubreason>,
         service: &mut S,
     ) where
-        S: Service<Id>,
+        S: PeerService<Id>,
     {
         self.connecting.remove(&addr);
         self.peers.remove(&addr);
@@ -131,7 +131,7 @@ impl<Id: PeerId> nakamoto_net::Reactor<Id> for Reactor<net::TcpStream, Id> {
         commands: chan::Receiver<S::Command>,
     ) -> Result<(), Error>
     where
-        S: Service<Id>,
+        S: PeerService<Id>,
         S::DisconnectSubreason: Into<DisconnectReason<S::DisconnectSubreason>>,
         E: Publisher<S::Event>,
     {
@@ -283,7 +283,7 @@ impl<Id: PeerId> Reactor<net::TcpStream, Id> {
     /// Process service state machine outputs.
     fn process<S, E>(&mut self, service: &mut S, publisher: &mut E, local_time: LocalTime)
     where
-        S: Service<Id>,
+        S: PeerService<Id>,
         E: Publisher<S::Event>,
         S::DisconnectSubreason: Into<DisconnectReason<S::DisconnectSubreason>>,
     {
@@ -350,7 +350,7 @@ impl<Id: PeerId> Reactor<net::TcpStream, Id> {
 
     fn handle_readable<S>(&mut self, addr: Id, service: &mut S)
     where
-        S: Service<Id>,
+        S: PeerService<Id>,
     {
         // Nb. If the socket was readable and writable at the same time, and it was disconnected
         // during an attempt to write, it will no longer be registered and hence available
@@ -404,7 +404,7 @@ impl<Id: PeerId> Reactor<net::TcpStream, Id> {
         }
     }
 
-    fn handle_writable<S: Service<Id>>(
+    fn handle_writable<S: PeerService<Id>>(
         &mut self,
         addr: Id,
         source: &Source<Id>,

--- a/net/poll/src/socket.rs
+++ b/net/poll/src/socket.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use std::io::{self, Read, Write};
 use std::net;
 
-use nakamoto_net::Link;
+use nakamoto_net::ConnDirection;
 
 use crate::fallible;
 
@@ -11,7 +11,7 @@ use crate::fallible;
 #[derive(Debug)]
 pub struct Socket<R: Read + Write> {
     pub address: net::SocketAddr,
-    pub link: Link,
+    pub link: ConnDirection,
 
     buffer: Vec<u8>,
     raw: R,
@@ -31,7 +31,7 @@ impl Socket<net::TcpStream> {
 
 impl<R: Read + Write> Socket<R> {
     /// Create a new socket from a `io::Read` and an address pair.
-    pub fn from(raw: R, address: net::SocketAddr, link: Link) -> Self {
+    pub fn from(raw: R, address: net::SocketAddr, link: ConnDirection) -> Self {
         Self {
             raw,
             link,

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -36,22 +36,25 @@ impl Link {
     }
 }
 
-/// Output of a state transition of the state machine.
+/// Instructions received from a network protocol state machine and dispatched
+/// by the reactor.
 #[derive(Debug)]
-pub enum Io<M, E, D, Id: PeerId = net::SocketAddr> {
+pub enum ReactorDispatch<M, E, D, Id: PeerId = net::SocketAddr> {
     /// There are some bytes ready to be sent to a peer.
     Write(Id, M),
     /// Connect to a peer.
     Connect(Id),
     /// Disconnect from a peer.
     Disconnect(Id, D),
-    /// Ask for a wakeup in a specified amount of time.
+    /// Ask for a wakeup in a specified amount of time once.
     Wakeup(LocalDuration),
     /// Emit an event.
     Event(E),
 }
 
-/// Disconnect reason.
+/// Disconnect reason originating either from the network interface or provided
+/// by the network protocol state machine in form of
+/// [`ReactorDispatch::Disconnect`] instruction.
 #[derive(Debug, Clone)]
 pub enum DisconnectReason<T> {
     /// Error while dialing the remote. This error occures before a connection is
@@ -84,7 +87,10 @@ impl<T: fmt::Display> fmt::Display for DisconnectReason<T> {
     }
 }
 
-/// Remote peer id, which must be convertible into a [`net::SocketAddr`]
+/// Remote peer id, which must be interconvertible with [`net::SocketAddr`].
+///
+/// Automatically implemented for all types which can be constructed from and
+/// converted into [`net::SocketAddr`].
 pub trait PeerId: Eq + Ord + Clone + Hash + fmt::Debug + From<net::SocketAddr> {
     fn to_socket_addr(&self) -> net::SocketAddr;
 }
@@ -103,26 +109,45 @@ where
 /// A network service.
 ///
 /// Network protocols must implement this trait to be drivable by the reactor.
-pub trait Service<Id: PeerId = net::SocketAddr>: StateMachine<Id, Message = [u8]> {
-    /// User commands handled by service.
+///
+/// A service is a protocols state machine which can be controlled from external
+/// user thread outside of the network event loop.
+pub trait Service<Id: PeerId = net::SocketAddr>: StateMachine<Id, PeerMessage = [u8]> {
+    /// Commands handled by service. These commands should originate from an
+    /// external "user" thread. They are passed through crossbeam channel provided
+    /// in the `commands_channel` argument to the [`Reactor::run`] method. The
+    /// commands are processed by the reactor calling [`Service::command_received`]
+    /// method.
     type Command;
 
-    /// An external command has been received.
-    fn command(&mut self, cmd: Self::Command);
+    /// A method that is called each time the service receives the command from
+    /// the user thread
+    fn command_received(&mut self, cmd: Self::Command);
 }
 
-/// A service state-machine.
+/// A state-machine for a network protocol business logic.
+///
+/// This trait defines API for connecting specific protocol business logic to the
+/// reactor implementation. It is parametrized by a peer id, which is the id
+/// provided to the business logic from the reactor.
+///
+/// State machine generates instructions to the reactor by operating as an
+/// iterator over .
 pub trait StateMachine<Id: PeerId = net::SocketAddr>:
-    Iterator<Item = Io<<Self::Message as ToOwned>::Owned, Self::Event, Self::DisconnectReason, Id>>
+    Iterator<Item = ReactorDispatch<<Self::PeerMessage as ToOwned>::Owned, Self::Event, Self::DisconnectSubreason, Id>>
 {
     /// Message type sent between peers.
-    type Message: fmt::Debug + ToOwned + ?Sized;
-    /// Events emitted by the state machine.
+    type PeerMessage: fmt::Debug + ToOwned + ?Sized;
+
+    /// Events which are sent by the reactor from the protocol state machine to
+    /// the user thread via publisher provided to the reactor.
     type Event: fmt::Debug;
-    /// Reason a peer was disconnected.
-    type DisconnectReason: fmt::Debug
+
+    /// Reason a peer was disconnected in case the disconnection was caused by
+    /// a state machine-specific reason.
+    type DisconnectSubreason: fmt::Debug
         + fmt::Display
-        + Into<DisconnectReason<Self::DisconnectReason>>;
+        + Into<DisconnectReason<Self::DisconnectSubreason>>;
 
     /// Initialize the state machine. Called once before any event is sent to the state machine.
     fn initialize(&mut self, _time: LocalTime) {
@@ -131,29 +156,44 @@ pub trait StateMachine<Id: PeerId = net::SocketAddr>:
         // and the sea-harvest of shells and tangle and veiled grey sunlight and gayclad lightclad
         // figures of children and girls and voices childish and girlish in the air." -JJ
     }
-    /// Received message from a peer.
-    fn received(&mut self, addr: &Id, message: Cow<Self::Message>);
+
+    /// Called by reactor upon receiving message from the remote peer.
+    fn received(&mut self, remote_peer: &Id, message: Cow<Self::PeerMessage>);
+
     /// Connection attempt underway.
     ///
     /// This is only encountered when an outgoing connection attempt is made,
     /// and is always called before [`StateMachine::connected`].
     ///
     /// For incoming connections, [`StateMachine::connected`] is called directly.
-    fn attempted(&mut self, addr: &Id);
-    /// New connection with a peer.
-    fn connected(&mut self, addr: Id, local_addr: &net::SocketAddr, link: Link);
-    /// Disconnected from peer.
-    fn disconnected(&mut self, addr: &Id, reason: DisconnectReason<Self::DisconnectReason>);
+    fn attempted(&mut self, remote_peer: &Id);
+
+    /// Called whenever a new connection with a peer is established.
+    fn connected(&mut self, remote_peer: Id, local_addr: &net::SocketAddr, link: Link);
+
+    /// Called whenever remote peer got disconnected, either because of the
+    /// network event or due to a local instruction from this state machine in
+    /// form of [`ReactorDispatch::Disconnect`]
+    fn disconnected(&mut self, remote_peer: &Id, reason: DisconnectReason<Self::DisconnectSubreason>);
+
+    /// Called by the reactor every time the event loop gets data from the network.
+    ///
     /// Used to update the state machine's internal clock.
     ///
     /// "a regular short, sharp sound, especially that made by a clock or watch, typically
     /// every second."
     fn tick(&mut self, local_time: LocalTime);
-    /// Used to advance the state machine after some timer rings.
+
+    /// Called by the reactor after a timeout whenever an Io::Wakeup was received
+    /// by the reactor from this state machine iterator. Used to advance the state
+    /// machine after some timer rings.
+    ///
+    /// NB: called together with [`StateMachine::wake`]
     fn wake(&mut self);
 }
 
-/// Used by certain types of reactors to wake the event loop.
+/// Used by certain types of reactors to wake the event loop to receive a user
+/// command.
 pub trait Waker: Send + Sync + Clone {
     /// Wake up! Call this after sending a command to make sure the command is processed
     /// in a timely fashion.
@@ -162,7 +202,7 @@ pub trait Waker: Send + Sync + Clone {
 
 /// Any network reactor that can drive the light-client service.
 pub trait Reactor<Id: PeerId = net::SocketAddr> {
-    /// The type of waker this reactor uses.
+    /// The type of [`Waker`] this reactor provides.
     type Waker: Waker;
 
     /// Create a new reactor, initializing it with a publisher for service events,
@@ -175,18 +215,33 @@ pub trait Reactor<Id: PeerId = net::SocketAddr> {
         Self: Sized;
 
     /// Run the given service with the reactor.
+    ///
+    /// # Arguments
+    ///
+    /// - `listen_addrs`: list of IP sockets to bind to;
+    /// - `service`: a concrete network protocol implementation to run in the
+    ///   reactor event loop;
+    /// - `publisher`: a concrete implementation of multiple subscribers single
+    ///   publisher channel, used by the reactor to provide user threads
+    ///   (subscribers) with the events of type `S::Event` emitted by the
+    ///   network `service` business logic;
+    /// - `commands_channel`: the receiver part of the channel with the user thread
+    ///   used to process commands from outside of the event loop.
     fn run<S, E>(
         &mut self,
         listen_addrs: &[net::SocketAddr],
         service: S,
         publisher: E,
-        commands: chan::Receiver<S::Command>,
+        commands_channel: chan::Receiver<S::Command>,
     ) -> Result<(), error::Error>
     where
         S: Service<Id>,
-        S::DisconnectReason: Into<DisconnectReason<S::DisconnectReason>>,
+        S::DisconnectSubreason: Into<DisconnectReason<S::DisconnectSubreason>>,
         E: Publisher<S::Event>;
 
-    /// Return a new waker.
+    /// Construct a new instance of the reactor waker.
+    ///
+    /// Reactor can provide multiple wakers such that multiple user threads will
+    /// be able to send a command to it.
     fn waker(&self) -> Self::Waker;
 }

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -155,11 +155,13 @@ pub trait PeerProtocol<Id: PeerId = net::SocketAddr>:
 
     /// Notifications which are sent by the reactor from the protocol state machine to
     /// the user thread via publisher provided to the reactor.
-    type Notification;
+    // TODO: Remove fmt::Debug requirement
+    type Notification: fmt::Debug;
 
     /// Reason a peer was disconnected in case the disconnection was demanded by
     /// this protocol.
-    type DisconnectDemand;
+    // TODO: Remove fmt::Display requirement
+    type DisconnectDemand: fmt::Display;
 
     /// Initialize the state machine. Called once before any event is sent to the state machine.
     fn initialize(&mut self, _time: LocalTime) {

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -226,23 +226,19 @@ pub trait Reactor<Id: PeerId = net::SocketAddr> {
     /// - `listen_addrs`: list of IP sockets to bind to;
     /// - `service`: a concrete network protocol implementation to run in the
     ///   reactor event loop;
-    /// - `publisher`: a concrete implementation of multiple subscribers single
+    /// - `notification_publisher`: a concrete implementation of multiple subscribers single
     ///   publisher channel, used by the reactor to provide user threads
-    ///   (subscribers) with the events of type `S::Event` emitted by the
-    ///   network `service` business logic;
-    /// - `commands_channel`: the receiver part of the channel with the user thread
+    ///   (subscribers) with the notifications of type `S::Notification`, emitted
+    ///   by the network `service` business logic;
+    /// - `commands_receiver`: the receiver part of the channel with the user thread
     ///   used to process commands from outside of the event loop.
-    fn run<S, E>(
+    fn run<N, C>(
         &mut self,
         listen_addrs: &[net::SocketAddr],
-        service: S,
-        publisher: E,
-        commands_channel: chan::Receiver<S::Command>,
-    ) -> Result<(), error::Error>
-    where
-        S: PeerService<Id>,
-        S::DisconnectSubreason: Into<DisconnectReason<S::DisconnectSubreason>>,
-        E: Publisher<S::Event>;
+        service: impl PeerService<Id, Notification = N, Command = C>,
+        notification_publisher: impl Publisher<N>,
+        commands_receiver: chan::Receiver<C>,
+    ) -> Result<(), error::Error>;
 
     /// Construct a new instance of the reactor waker.
     ///

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -87,6 +87,12 @@ impl<T: fmt::Display> fmt::Display for DisconnectReason<T> {
     }
 }
 
+impl<T> From<T> for DisconnectReason<T> {
+    fn from(r: T) -> Self {
+        DisconnectReason::StateMachine(r)
+    }
+}
+
 /// Remote peer id, which must be interconvertible with [`net::SocketAddr`].
 ///
 /// Automatically implemented for all types which can be constructed from and
@@ -145,9 +151,7 @@ pub trait PeerProtocol<Id: PeerId = net::SocketAddr>:
 
     /// Reason a peer was disconnected in case the disconnection was caused by
     /// a state machine-specific reason.
-    type DisconnectSubreason: fmt::Debug
-        + fmt::Display
-        + Into<DisconnectReason<Self::DisconnectSubreason>>;
+    type DisconnectSubreason;
 
     /// Initialize the state machine. Called once before any event is sent to the state machine.
     fn initialize(&mut self, _time: LocalTime) {

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -141,7 +141,14 @@ pub trait PeerService<Id: PeerId = net::SocketAddr>: PeerProtocol<Id, PeerMessag
 /// State machine generates instructions to the reactor by operating as an
 /// iterator over .
 pub trait PeerProtocol<Id: PeerId = net::SocketAddr>:
-    Iterator<Item = ReactorDispatch<<Self::PeerMessage as ToOwned>::Owned, Self::Notification, Self::DisconnectDemand, Id>>
+    Iterator<
+    Item = ReactorDispatch<
+        <Self::PeerMessage as ToOwned>::Owned,
+        Self::Notification,
+        Self::DisconnectDemand,
+        Id,
+    >,
+>
 {
     /// Message type sent between peers.
     type PeerMessage: ToOwned + ?Sized;

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -91,6 +91,8 @@ impl<T: fmt::Display> fmt::Display for DisconnectReason<T> {
 ///
 /// Automatically implemented for all types which can be constructed from and
 /// converted into [`net::SocketAddr`].
+// TODO: Investigate a problem that a PeerId can't be constructed with the remote
+//       peer public key from just a socket address upon `accept`.
 pub trait PeerId: Eq + Ord + Clone + Hash + fmt::Debug + From<net::SocketAddr> {
     fn to_socket_addr(&self) -> net::SocketAddr;
 }

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -123,7 +123,7 @@ pub trait PeerService<Id: PeerId = net::SocketAddr>: PeerProtocol<Id, PeerMessag
     /// Commands handled by service. These commands should originate from an
     /// external "user" thread. They are passed through crossbeam channel provided
     /// in the `commands_channel` argument to the [`Reactor::run`] method. The
-    /// commands are processed by the reactor calling [`Service::command_received`]
+    /// commands are processed by the reactor calling [`Self::command_received`]
     /// method.
     type Command;
 
@@ -177,9 +177,9 @@ pub trait PeerProtocol<Id: PeerId = net::SocketAddr>:
     /// Connection attempt underway.
     ///
     /// This is only encountered when an outgoing connection attempt is made,
-    /// and is always called before [`StateMachine::connected`].
+    /// and is always called before [`Self::connected`].
     ///
-    /// For incoming connections, [`StateMachine::connected`] is called directly.
+    /// For incoming connections, [`Self::connected`] is called directly.
     fn attempted(&mut self, remote_peer: &Id);
 
     /// Called whenever a new connection with a peer is established.
@@ -187,7 +187,7 @@ pub trait PeerProtocol<Id: PeerId = net::SocketAddr>:
 
     /// Called whenever remote peer got disconnected, either because of the
     /// network event or due to a local instruction from this state machine in
-    /// form of [`ReactorDispatch::Disconnect`]
+    /// form of [`ReactorDispatch::DisconnectPeer`]
     fn disconnected(&mut self, remote_peer: &Id, reason: DisconnectReason<Self::DisconnectDemand>);
 
     /// Called by the reactor every time the event loop gets data from the network.
@@ -201,7 +201,7 @@ pub trait PeerProtocol<Id: PeerId = net::SocketAddr>:
     /// Called by the reactor after a timeout whenever an [`ReactorDispatch::SetTimer`]
     /// was received by the reactor from this iterator.
     ///
-    /// NB: on each of this calls [`StateMachine::tick`] is also called.
+    /// NB: on each of this calls [`Self::tick`] is also called.
     fn on_timer(&mut self);
 }
 

--- a/net/src/simulator.rs
+++ b/net/src/simulator.rs
@@ -1,7 +1,7 @@
 //! A simple P2P network simulator. Acts as the _reactor_, but without doing any I/O.
 #![allow(clippy::collapsible_if)]
 
-use crate::{DisconnectReason, ReactorDispatch, ConnDirection, LocalDuration, LocalTime};
+use crate::{ConnDirection, DisconnectReason, LocalDuration, LocalTime, ReactorDispatch};
 use log::*;
 
 use std::borrow::Cow;
@@ -416,7 +416,12 @@ where
     pub fn schedule(
         &mut self,
         node: &NodeId,
-        out: ReactorDispatch<<T::PeerMessage as ToOwned>::Owned, T::Notification, T::DisconnectDemand, net::SocketAddr>,
+        out: ReactorDispatch<
+            <T::PeerMessage as ToOwned>::Owned,
+            T::Notification,
+            T::DisconnectDemand,
+            net::SocketAddr,
+        >,
     ) {
         let node = *node;
 

--- a/net/src/simulator.rs
+++ b/net/src/simulator.rs
@@ -167,11 +167,11 @@ where
     T: PeerProtocol,
 {
     /// Inbox of inputs to be delivered by the simulation.
-    inbox: Inbox<<T::PeerMessage as ToOwned>::Owned, T::DisconnectSubreason>,
+    inbox: Inbox<<T::PeerMessage as ToOwned>::Owned, T::DisconnectDemand>,
     /// Events emitted during simulation.
     events: BTreeMap<NodeId, VecDeque<T::Notification>>,
     /// Priority events that should happen immediately.
-    priority: VecDeque<Scheduled<<T::PeerMessage as ToOwned>::Owned, T::DisconnectSubreason>>,
+    priority: VecDeque<Scheduled<<T::PeerMessage as ToOwned>::Owned, T::DisconnectDemand>>,
     /// Simulated latencies between nodes.
     latencies: BTreeMap<(NodeId, NodeId), LocalDuration>,
     /// Network partitions between two nodes.
@@ -193,7 +193,7 @@ where
 impl<T> Simulation<T>
 where
     T: PeerProtocol + 'static,
-    T::DisconnectSubreason: Clone + fmt::Debug + fmt::Display,
+    T::DisconnectDemand: Clone + fmt::Debug + fmt::Display,
 
     <T::PeerMessage as ToOwned>::Owned: fmt::Debug + Clone,
 {
@@ -394,7 +394,7 @@ where
                             p.disconnected(&addr, reason);
                         }
                     }
-                    Input::Wake => p.wake(),
+                    Input::Wake => p.on_timer(),
                     Input::Received(addr, msg) => {
                         p.received(&addr, Cow::Owned(msg));
                     }
@@ -416,7 +416,7 @@ where
     pub fn schedule(
         &mut self,
         node: &NodeId,
-        out: ReactorDispatch<<T::PeerMessage as ToOwned>::Owned, T::Notification, T::DisconnectSubreason, net::SocketAddr>,
+        out: ReactorDispatch<<T::PeerMessage as ToOwned>::Owned, T::Notification, T::DisconnectDemand, net::SocketAddr>,
     ) {
         let node = *node;
 

--- a/net/src/simulator.rs
+++ b/net/src/simulator.rs
@@ -193,7 +193,7 @@ where
 impl<T> Simulation<T>
 where
     T: PeerProtocol + 'static,
-    T::DisconnectSubreason: Clone + Into<DisconnectReason<T::DisconnectSubreason>>,
+    T::DisconnectSubreason: Clone + fmt::Debug + fmt::Display,
 
     <T::PeerMessage as ToOwned>::Owned: fmt::Debug + Clone,
 {

--- a/net/src/simulator.rs
+++ b/net/src/simulator.rs
@@ -9,7 +9,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::ops::{Deref, DerefMut, Range};
 use std::{fmt, io, net};
 
-use crate::StateMachine;
+use crate::PeerProtocol;
 
 #[cfg(feature = "quickcheck")]
 pub mod arbitrary;
@@ -26,7 +26,7 @@ type NodeId = net::IpAddr;
 /// A simulated peer. Protocol instances have to be wrapped in this type to be simulated.
 pub trait Peer<P>: Deref<Target = P> + DerefMut<Target = P> + 'static
 where
-    P: StateMachine,
+    P: PeerProtocol,
 {
     /// Initialize the peer. This should at minimum initialize the protocol with the
     /// current time.
@@ -164,7 +164,7 @@ impl Default for Options {
 /// A peer-to-peer node simulation.
 pub struct Simulation<T>
 where
-    T: StateMachine,
+    T: PeerProtocol,
 {
     /// Inbox of inputs to be delivered by the simulation.
     inbox: Inbox<<T::PeerMessage as ToOwned>::Owned, T::DisconnectSubreason>,
@@ -192,7 +192,7 @@ where
 
 impl<T> Simulation<T>
 where
-    T: StateMachine + 'static,
+    T: PeerProtocol + 'static,
     T::DisconnectSubreason: Clone + Into<DisconnectReason<T::DisconnectSubreason>>,
 
     <T::PeerMessage as ToOwned>::Owned: fmt::Debug + Clone,

--- a/p2p/src/fsm.rs
+++ b/p2p/src/fsm.rs
@@ -761,7 +761,7 @@ impl<T: BlockTree, F: Filters, P: peer::Store, C: AdjustedClock<PeerId>> traits:
 {
     type PeerMessage = RawNetworkMessage;
     type Notification = Event;
-    type DisconnectSubreason = DisconnectReason;
+    type DisconnectDemand = DisconnectReason;
 
     fn initialize(&mut self, time: LocalTime) {
         self.clock.set(time);
@@ -996,7 +996,7 @@ impl<T: BlockTree, F: Filters, P: peer::Store, C: AdjustedClock<PeerId>> traits:
         self.clock.set(local_time);
     }
 
-    fn wake(&mut self) {
+    fn on_timer(&mut self) {
         trace!("Received wake");
 
         self.invmgr.received_wake(&self.tree);

--- a/p2p/src/fsm.rs
+++ b/p2p/src/fsm.rs
@@ -759,9 +759,9 @@ impl<T: BlockTree, F: Filters, P: peer::Store, C: AdjustedClock<PeerId>> StateMa
 impl<T: BlockTree, F: Filters, P: peer::Store, C: AdjustedClock<PeerId>> traits::StateMachine
     for StateMachine<T, F, P, C>
 {
-    type Message = RawNetworkMessage;
+    type PeerMessage = RawNetworkMessage;
     type Event = Event;
-    type DisconnectReason = DisconnectReason;
+    type DisconnectSubreason = DisconnectReason;
 
     fn initialize(&mut self, time: LocalTime) {
         self.clock.set(time);

--- a/p2p/src/fsm.rs
+++ b/p2p/src/fsm.rs
@@ -966,7 +966,12 @@ impl<T: BlockTree, F: Filters, P: peer::Store, C: AdjustedClock<PeerId>> traits:
         self.peermgr.peer_attempted(addr);
     }
 
-    fn connected(&mut self, addr: net::SocketAddr, local_addr: &net::SocketAddr, link: ConnDirection) {
+    fn connected(
+        &mut self,
+        addr: net::SocketAddr,
+        local_addr: &net::SocketAddr,
+        link: ConnDirection,
+    ) {
         let height = self.tree.height();
 
         self.addrmgr.record_local_address(*local_addr);

--- a/p2p/src/fsm.rs
+++ b/p2p/src/fsm.rs
@@ -159,12 +159,6 @@ impl DisconnectReason {
     }
 }
 
-impl From<DisconnectReason> for nakamoto_net::DisconnectReason<DisconnectReason> {
-    fn from(reason: DisconnectReason) -> Self {
-        Self::OnDemand(reason)
-    }
-}
-
 impl fmt::Display for DisconnectReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/p2p/src/fsm.rs
+++ b/p2p/src/fsm.rs
@@ -756,7 +756,7 @@ impl<T: BlockTree, F: Filters, P: peer::Store, C: AdjustedClock<PeerId>> StateMa
     }
 }
 
-impl<T: BlockTree, F: Filters, P: peer::Store, C: AdjustedClock<PeerId>> traits::StateMachine
+impl<T: BlockTree, F: Filters, P: peer::Store, C: AdjustedClock<PeerId>> traits::PeerProtocol
     for StateMachine<T, F, P, C>
 {
     type PeerMessage = RawNetworkMessage;

--- a/p2p/src/fsm/addrmgr.rs
+++ b/p2p/src/fsm/addrmgr.rs
@@ -230,7 +230,12 @@ impl<P: Store, U: Wire<Event> + Wakeup, C: Clock> AddressManager<P, U, C> {
     }
 
     /// Called when a peer has handshaked.
-    pub fn peer_negotiated(&mut self, addr: &net::SocketAddr, services: ServiceFlags, link: ConnDirection) {
+    pub fn peer_negotiated(
+        &mut self,
+        addr: &net::SocketAddr,
+        services: ServiceFlags,
+        link: ConnDirection,
+    ) {
         let time = self.clock.local_time();
 
         if !self.connected.contains(&addr.ip()) {
@@ -806,7 +811,11 @@ mod tests {
         // If a peer has been connected to successfully, and then disconnected for a transient
         // reason, its address should be once again available.
         addrmgr.peer_connected(&([44, 44, 44, 44], 8333).into());
-        addrmgr.peer_negotiated(&([44, 44, 44, 44], 8333).into(), services, ConnDirection::Outbound);
+        addrmgr.peer_negotiated(
+            &([44, 44, 44, 44], 8333).into(),
+            services,
+            ConnDirection::Outbound,
+        );
         addrmgr.peer_disconnected(
             &([44, 44, 44, 44], 8333).into(),
             fsm::DisconnectReason::PeerTimeout("timeout").into(),

--- a/p2p/src/fsm/cbfmgr.rs
+++ b/p2p/src/fsm/cbfmgr.rs
@@ -22,7 +22,7 @@ use nakamoto_common::source;
 
 use super::filter_cache::FilterCache;
 use super::output::{Disconnect, Wakeup, Wire};
-use super::{DisconnectReason, Link, PeerId, Socket};
+use super::{DisconnectReason, ConnDirection, PeerId, Socket};
 
 use rescan::Rescan;
 
@@ -818,7 +818,7 @@ impl<F: Filters, U: Wire<Event> + Wakeup + Disconnect, C: Clock> FilterManager<F
         socket: Socket,
         height: Height,
         services: ServiceFlags,
-        link: Link,
+        link: ConnDirection,
         persistent: bool,
         tree: &T,
     ) {
@@ -1168,7 +1168,7 @@ mod tests {
 
         pub fn events(outputs: impl Iterator<Item = fsm::Io>) -> impl Iterator<Item = Event> {
             outputs.filter_map(|o| match o {
-                fsm::Io::Event(fsm::Event::Filter(e)) => Some(e),
+                fsm::Io::NotifySubscribers(fsm::Event::Filter(e)) => Some(e),
                 _ => None,
             })
         }
@@ -1303,7 +1303,7 @@ mod tests {
             Socket::new(remote),
             best,
             REQUIRED_SERVICES,
-            Link::Outbound,
+            ConnDirection::Outbound,
             false,
             &tree,
         );
@@ -1365,7 +1365,7 @@ mod tests {
             Socket::new(remote),
             best,
             REQUIRED_SERVICES,
-            Link::Outbound,
+            ConnDirection::Outbound,
             false,
             &tree,
         );
@@ -1425,7 +1425,7 @@ mod tests {
             Socket::new(remote),
             best,
             REQUIRED_SERVICES,
-            Link::Outbound,
+            ConnDirection::Outbound,
             false,
             &tree,
         );
@@ -1525,7 +1525,7 @@ mod tests {
             Socket::new(remote),
             header_height,
             REQUIRED_SERVICES,
-            Link::Outbound,
+            ConnDirection::Outbound,
             false,
             &tree,
         );
@@ -1581,7 +1581,7 @@ mod tests {
             Socket::new(remote),
             best,
             REQUIRED_SERVICES,
-            Link::Outbound,
+            ConnDirection::Outbound,
             false,
             &tree,
         );
@@ -1673,7 +1673,7 @@ mod tests {
             Socket::new(remote),
             best,
             REQUIRED_SERVICES,
-            Link::Outbound,
+            ConnDirection::Outbound,
             false,
             &tree,
         );
@@ -1787,7 +1787,7 @@ mod tests {
             Socket::new(remote),
             best,
             REQUIRED_SERVICES,
-            Link::Outbound,
+            ConnDirection::Outbound,
             false,
             &tree,
         );
@@ -1877,7 +1877,7 @@ mod tests {
             Socket::new(remote),
             best,
             REQUIRED_SERVICES,
-            Link::Outbound,
+            ConnDirection::Outbound,
             false,
             &tree,
         );
@@ -1957,7 +1957,7 @@ mod tests {
             Socket::new(remote),
             best,
             REQUIRED_SERVICES,
-            Link::Outbound,
+            ConnDirection::Outbound,
             false,
             &tree,
         );
@@ -2053,7 +2053,7 @@ mod tests {
                 Socket::new(remote),
                 best,
                 REQUIRED_SERVICES,
-                Link::Outbound,
+                ConnDirection::Outbound,
                 false,
                 &tree,
             );
@@ -2177,7 +2177,7 @@ mod tests {
             Socket::new(remote),
             best,
             REQUIRED_SERVICES,
-            Link::Outbound,
+            ConnDirection::Outbound,
             false,
             &tree,
         );

--- a/p2p/src/fsm/cbfmgr.rs
+++ b/p2p/src/fsm/cbfmgr.rs
@@ -22,7 +22,7 @@ use nakamoto_common::source;
 
 use super::filter_cache::FilterCache;
 use super::output::{Disconnect, Wakeup, Wire};
-use super::{DisconnectReason, ConnDirection, PeerId, Socket};
+use super::{ConnDirection, DisconnectReason, PeerId, Socket};
 
 use rescan::Rescan;
 

--- a/p2p/src/fsm/invmgr.rs
+++ b/p2p/src/fsm/invmgr.rs
@@ -577,7 +577,7 @@ mod tests {
 
     fn events(outputs: impl Iterator<Item = Io>) -> impl Iterator<Item = Event> {
         outputs.filter_map(|o| match o {
-            Io::Event(fsm::Event::Inventory(e)) => Some(e),
+            Io::NotifySubscribers(fsm::Event::Inventory(e)) => Some(e),
             _ => None,
         })
     }
@@ -667,7 +667,7 @@ mod tests {
         assert_eq!(
             upstream
                 .drain()
-                .filter(|o| matches!(o, Io::Write(_, _)))
+                .filter(|o| matches!(o, Io::SendPeer(_, _)))
                 .count(),
             0,
             "No more requests are sent"

--- a/p2p/src/fsm/output.rs
+++ b/p2p/src/fsm/output.rs
@@ -30,7 +30,7 @@ use super::network::Network;
 use super::Locators;
 
 /// Output of a state transition of the `Protocol` state machine.
-pub type Io = nakamoto_net::Io<RawNetworkMessage, Event, super::DisconnectReason>;
+pub type Io = nakamoto_net::ReactorDispatch<RawNetworkMessage, Event, super::DisconnectReason>;
 
 impl From<Event> for Io {
     fn from(event: Event) -> Self {

--- a/p2p/src/fsm/peermgr.rs
+++ b/p2p/src/fsm/peermgr.rs
@@ -34,7 +34,7 @@ use crate::fsm::addrmgr;
 use crate::fsm::DisconnectReason;
 
 use super::output::{Connect, Disconnect, Wakeup, Wire};
-use super::{Hooks, ConnDirection, PeerId, Socket, Whitelist};
+use super::{ConnDirection, Hooks, PeerId, Socket, Whitelist};
 
 /// Time to wait for response during peer handshake before disconnecting the peer.
 pub const HANDSHAKE_TIMEOUT: LocalDuration = LocalDuration::from_secs(12);
@@ -784,7 +784,10 @@ impl<U: Connect + Disconnect + Wakeup + Wire<Event>, C: Clock> PeerManager<U, C>
     }
 
     /// Iterator over fully negotiated peers.
-    pub fn negotiated(&self, link: ConnDirection) -> impl Iterator<Item = (&PeerInfo, &Connection)> + Clone {
+    pub fn negotiated(
+        &self,
+        link: ConnDirection,
+    ) -> impl Iterator<Item = (&PeerInfo, &Connection)> + Clone {
         self.peers()
             .filter(move |(p, c)| p.is_negotiated() && c.link == link)
     }

--- a/p2p/src/fsm/syncmgr.rs
+++ b/p2p/src/fsm/syncmgr.rs
@@ -14,7 +14,7 @@ use nakamoto_common::collections::{AddressBook, HashMap};
 use nakamoto_common::nonempty::NonEmpty;
 
 use super::output::{Disconnect, Wakeup, Wire};
-use super::{DisconnectReason, Link, Locators, PeerId, Socket};
+use super::{DisconnectReason, ConnDirection, Locators, PeerId, Socket};
 
 /// How long to wait for a request, eg. `getheaders` to be fulfilled.
 pub const REQUEST_TIMEOUT: LocalDuration = LocalDuration::from_secs(30);
@@ -52,7 +52,7 @@ struct Peer {
     height: Height,
     preferred: bool,
     tip: BlockHash,
-    link: Link,
+    link: ConnDirection,
     last_active: Option<LocalTime>,
     last_asked: Option<Locators>,
 
@@ -241,7 +241,7 @@ impl<U: Wakeup + Disconnect + Wire<Event>, C: Clock> SyncManager<U, C> {
         height: Height,
         services: ServiceFlags,
         preferred: bool,
-        link: Link,
+        link: ConnDirection,
         tree: &T,
     ) {
         if link.is_outbound() && !services.has(REQUIRED_SERVICES) {
@@ -607,7 +607,7 @@ impl<U: Wakeup + Disconnect + Wire<Event>, C: Clock> SyncManager<U, C> {
     }
 
     /// Register a new peer.
-    fn register(&mut self, socket: Socket, height: Height, preferred: bool, link: Link) {
+    fn register(&mut self, socket: Socket, height: Height, preferred: bool, link: ConnDirection) {
         let last_active = None;
         let last_asked = None;
         let tip = BlockHash::all_zeros();
@@ -735,7 +735,7 @@ impl<U: Wakeup + Disconnect + Wire<Event>, C: Clock> SyncManager<U, C> {
         if let Some((height, best)) = tree.get_block(hash) {
             for (addr, peer) in &*self.peers {
                 // TODO: Don't broadcast to peer that is currently syncing?
-                if peer.link == Link::Inbound && height > peer.height {
+                if peer.link == ConnDirection::Inbound && height > peer.height {
                     self.upstream.headers(*addr, vec![*best]);
                 }
             }

--- a/p2p/src/fsm/syncmgr.rs
+++ b/p2p/src/fsm/syncmgr.rs
@@ -14,7 +14,7 @@ use nakamoto_common::collections::{AddressBook, HashMap};
 use nakamoto_common::nonempty::NonEmpty;
 
 use super::output::{Disconnect, Wakeup, Wire};
-use super::{DisconnectReason, ConnDirection, Locators, PeerId, Socket};
+use super::{ConnDirection, DisconnectReason, Locators, PeerId, Socket};
 
 /// How long to wait for a request, eg. `getheaders` to be fulfilled.
 pub const REQUEST_TIMEOUT: LocalDuration = LocalDuration::from_secs(30);

--- a/p2p/src/fsm/tests.rs
+++ b/p2p/src/fsm/tests.rs
@@ -29,7 +29,7 @@ use nakamoto_common::bitcoin::network::Address;
 use nakamoto_common::bitcoin_hashes::hex::FromHex;
 use nakamoto_common::block::time::Clock as _;
 use nakamoto_net::simulator::{Options, Peer as _, Simulation};
-use nakamoto_net::{Link, LocalDuration, LocalTime, StateMachine as _};
+use nakamoto_net::{Link, LocalDuration, LocalTime, PeerProtocol as _};
 
 use quickcheck_macros::quickcheck;
 

--- a/p2p/src/fsm/tests/peer.rs
+++ b/p2p/src/fsm/tests/peer.rs
@@ -209,11 +209,11 @@ impl Peer<Protocol> {
     pub fn elapse(&mut self, duration: LocalDuration) {
         let time = self.clock.local_time();
         self.clock.borrow_mut().set_local_time(time + duration);
-        self.protocol.wake();
+        self.protocol.on_timer();
     }
 
     pub fn tock(&mut self) {
-        self.protocol.wake();
+        self.protocol.on_timer();
     }
 
     pub fn outputs(&mut self) -> impl Iterator<Item = Io> + '_ {

--- a/p2p/src/fsm/tests/peer.rs
+++ b/p2p/src/fsm/tests/peer.rs
@@ -192,7 +192,7 @@ impl Peer<Protocol> {
         self.protocol.clock.local_time()
     }
 
-    pub fn connect_addr(&mut self, addr: &PeerId, link: Link) {
+    pub fn connect_addr(&mut self, addr: &PeerId, link: ConnDirection) {
         self.connect(
             &PeerDummy {
                 addr: *addr,
@@ -229,7 +229,7 @@ impl Peer<Protocol> {
 
     pub fn events(&mut self) -> impl Iterator<Item = Event> + '_ {
         self.protocol.drain().filter_map(|o| match o {
-            Io::Event(e) => Some(e),
+            Io::NotifySubscribers(e) => Some(e),
             _ => None,
         })
     }
@@ -252,7 +252,7 @@ impl Peer<Protocol> {
         self.protocol.drain().for_each(drop);
     }
 
-    pub fn connect(&mut self, remote: &PeerDummy, link: Link) {
+    pub fn connect(&mut self, remote: &PeerDummy, link: ConnDirection) {
         <Self as simulator::Peer<Protocol>>::init(self);
 
         let local = self.addr;
@@ -294,7 +294,7 @@ impl Peer<Protocol> {
             .find(|o| {
                 matches!(
                     o,
-                    Io::Event(
+                    Io::NotifySubscribers(
                         Event::Peer(peermgr::Event::Negotiated { addr, services, .. })
                     ) if addr == &remote.addr && services.has(ServiceFlags::NETWORK)
                 )

--- a/p2p/src/fsm/tests/simulations.rs
+++ b/p2p/src/fsm/tests/simulations.rs
@@ -33,7 +33,7 @@ pub fn connect_to_peers(
     let (mut prev_negotiated, mut prev_connecting, mut prev_connected) = (0, 0, 0);
 
     while simulator.step(iter::once(&mut alice).chain(&mut peers)) {
-        let negotiated = alice.protocol.peermgr.negotiated(Link::Outbound).count();
+        let negotiated = alice.protocol.peermgr.negotiated(ConnDirection::Outbound).count();
         let connecting = alice.protocol.peermgr.connecting().count();
         let connected = alice.protocol.peermgr.connected().count();
 

--- a/p2p/src/fsm/tests/simulations.rs
+++ b/p2p/src/fsm/tests/simulations.rs
@@ -33,7 +33,11 @@ pub fn connect_to_peers(
     let (mut prev_negotiated, mut prev_connecting, mut prev_connected) = (0, 0, 0);
 
     while simulator.step(iter::once(&mut alice).chain(&mut peers)) {
-        let negotiated = alice.protocol.peermgr.negotiated(ConnDirection::Outbound).count();
+        let negotiated = alice
+            .protocol
+            .peermgr
+            .negotiated(ConnDirection::Outbound)
+            .count();
         let connecting = alice.protocol.peermgr.connecting().count();
         let connected = alice.protocol.peermgr.connected().count();
 

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -27,5 +27,5 @@
 pub mod fsm;
 pub mod stream;
 
-pub use fsm::{Command, Config, DisconnectReason, Event, Io, Link, PeerId, StateMachine};
+pub use fsm::{Command, Config, DisconnectReason, Event, Io, ConnDirection, PeerId, StateMachine};
 pub use nakamoto_net as net;

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -27,5 +27,5 @@
 pub mod fsm;
 pub mod stream;
 
-pub use fsm::{Command, Config, DisconnectReason, Event, Io, ConnDirection, PeerId, StateMachine};
+pub use fsm::{Command, Config, ConnDirection, DisconnectReason, Event, Io, PeerId, StateMachine};
 pub use nakamoto_net as net;


### PR DESCRIPTION
Most of the changes are automatic rename. Only https://github.com/cloudhead/nakamoto/pull/115/files#diff-77f33230aa3d7e93c6a9f170ec077a1be8e66fedd55a3bf661bec10408444604 needs to be reviewed; all other changes are automatic consequence