### PR TITLE
[client] Optional filter header verification

### DIFF
--- a/common/src/block/tree.rs
+++ b/common/src/block/tree.rs
@@ -48,6 +48,10 @@ pub enum Error {
     #[error("block import aborted at height {2}: {0} ({1} block(s) imported)")]
     BlockImportAborted(Box<Self>, usize, Height),
 
+    /// Mismatched genesis.
+    #[error("stored genesis header doesn't match network genesis")]
+    GenesisMismatch,
+
     /// A storage error occured.
     #[error("storage error: {0}")]
     Store(#[from] store::Error),

--- a/p2p/src/fsm/syncmgr.rs
+++ b/p2p/src/fsm/syncmgr.rs
@@ -570,9 +570,9 @@ impl<U: Wakeup + Disconnect + Wire<Event>, C: Clock> SyncManager<U, C> {
             // TODO: This will be removed.
             Error::BlockImportAborted(_, _, _) => Ok(()),
 
-            // This shouldn't happen here.
+            // These shouldn't happen here.
             // TODO: Perhaps there's a better way to have this error not show up here.
-            Error::Interrupted => Ok(()),
+            Error::Interrupted | Error::GenesisMismatch => Ok(()),
         }
     }
 


### PR DESCRIPTION
This update allows us to control whether filter verification takes place. It's a useful option for debugging when we know that the local store is healthy.