### PR TITLE
increase bitcoin version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bitcoin"
-version = "0.29.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb36de3b18ad25f396f9168302e36fb7e1e8923298ab3127da252d288d5af9d"
+checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
 dependencies = [
  "bech32",
  "bitcoin_hashes",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 nakamoto-net = { version = "0.3.0", path = "../net" }
-bitcoin = "0.29.1"
+bitcoin = "0.29.2"
 bitcoin_hashes = "0.11.0"
 thiserror = "1.0"
 fastrand = "1.3.5"


### PR DESCRIPTION
I'm still a bit confused about this change because the changelog lack what this version includes https://github.com/rust-bitcoin/rust-bitcoin/blob/HEAD/CHANGELOG.md

There is someone with more info on that? 

The main reason that I would like to bump the last version is for the security vulnerability patch, but I'm not sure if this includes any path for the last vulnerability found

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>