### PR TITLE
calculate chainwork at header by hash

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -488,7 +488,7 @@ impl<W: Waker> handle::Handle for Handle<W> {
         Ok(receive.recv()?)
     }
 
-    fn get_block(&self, hash: &BlockHash) -> Result<Option<(Height, BlockHeader)>, handle::Error> {
+    fn get_block(&self, hash: &BlockHash) -> Result<Option<(Height, BlockHeader, Uint256)>, handle::Error> {
         let (transmit, receive) = chan::bounded(1);
         self._command(Command::GetBlockByHash(*hash, transmit))?;
 

--- a/client/src/handle.rs
+++ b/client/src/handle.rs
@@ -68,7 +68,7 @@ pub trait Handle: Sized + Send + Sync + Clone {
     /// and the total accumulated work.
     fn get_tip(&self) -> Result<(Height, BlockHeader, Uint256), Error>;
     /// Get a block header from the block header cache.
-    fn get_block(&self, hash: &BlockHash) -> Result<Option<(Height, BlockHeader)>, Error>;
+    fn get_block(&self, hash: &BlockHash) -> Result<Option<(Height, BlockHeader, Uint256)>, Error>;
     /// Get a block header by height, from the block header cache.
     fn get_block_by_height(&self, height: Height) -> Result<Option<BlockHeader>, Error>;
     /// Query the local block tree using the given function. To return results from


### PR DESCRIPTION
This calculates the total chainwork at the requested header by iterating all headers from the requested one to the current tip and subtracting the work as we go.

There might be an off-by-one issue here depending on how range works exactly.  If requested header height === tip_height then we don't want to iterate any headers at all and just return the current chainwork.