### PR TITLE
client: introduce API model

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -39,6 +39,7 @@ pub use nakamoto_p2p::fsm::{Command, CommandError, Hooks, Limits, Link, Peer};
 pub use crate::error::Error;
 pub use crate::event::{Event, Loading};
 pub use crate::handle;
+use crate::model::Tip;
 pub use crate::service::Service;
 
 use crate::event::Mapper;
@@ -481,11 +482,11 @@ impl<W: Waker> Handle<W> {
 }
 
 impl<W: Waker> handle::Handle for Handle<W> {
-    fn get_tip(&self) -> Result<(Height, BlockHeader, Uint256), handle::Error> {
+    fn get_tip(&self) -> Result<Tip, handle::Error> {
         let (transmit, receive) = chan::bounded::<(Height, BlockHeader, Uint256)>(1);
         self._command(Command::GetTip(transmit))?;
 
-        Ok(receive.recv()?)
+        Ok(receive.recv()?.into())
     }
 
     fn get_block(&self, hash: &BlockHash) -> Result<Option<(Height, BlockHeader)>, handle::Error> {

--- a/client/src/handle.rs
+++ b/client/src/handle.rs
@@ -8,7 +8,6 @@ use thiserror::Error;
 
 use nakamoto_common::bitcoin::network::constants::ServiceFlags;
 use nakamoto_common::bitcoin::network::Address;
-use nakamoto_common::bitcoin::util::uint::Uint256;
 use nakamoto_common::bitcoin::Script;
 
 use nakamoto_common::bitcoin::network::message::NetworkMessage;
@@ -20,6 +19,7 @@ use nakamoto_p2p::fsm::Link;
 use nakamoto_p2p::fsm::{self, Command, CommandError, GetFiltersError, Peer};
 
 use crate::client::Event;
+use crate::model::Tip;
 
 /// An error resulting from a handle method.
 #[derive(Error, Debug)]
@@ -66,7 +66,7 @@ impl<T> From<chan::SendError<T>> for Error {
 pub trait Handle: Sized + Send + Sync + Clone {
     /// Get the tip of the active chain. Returns the height of the chain, the header,
     /// and the total accumulated work.
-    fn get_tip(&self) -> Result<(Height, BlockHeader, Uint256), Error>;
+    fn get_tip(&self) -> Result<Tip, Error>;
     /// Get a block header from the block header cache.
     fn get_block(&self, hash: &BlockHash) -> Result<Option<(Height, BlockHeader)>, Error>;
     /// Get a block header by height, from the block header cache.

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -10,6 +10,7 @@ mod service;
 
 pub use client::*;
 pub mod handle;
+pub mod model;
 
 #[cfg(test)]
 mod tests;

--- a/client/src/model.rs
+++ b/client/src/model.rs
@@ -1,0 +1,25 @@
+//! Client API model
+use nakamoto_chain::BlockHeader;
+use nakamoto_common::bitcoin::util::uint::Uint256;
+use nakamoto_common::block::Height;
+
+/// Tip Network with the information regarding the chain.
+#[allow(dead_code)]
+pub struct Tip {
+    /// current chain height
+    pub height: Height,
+    /// Block Header
+    pub blk_header: BlockHeader,
+    /// total accumulated work
+    pub works: Uint256,
+}
+
+impl From<(Height, BlockHeader, Uint256)> for Tip {
+    fn from(val: (Height, BlockHeader, Uint256)) -> Self {
+        Tip {
+            height: val.0,
+            blk_header: val.1,
+            works: val.2,
+        }
+    }
+}

--- a/client/src/tests/mock.rs
+++ b/client/src/tests/mock.rs
@@ -31,6 +31,7 @@ use nakamoto_p2p::fsm::StateMachine;
 use crate::client::{chan, Event, Loading};
 use crate::event::Mapper;
 use crate::handle::{self, Handle};
+use crate::model::Tip;
 
 pub struct Client {
     // Used by tests.
@@ -147,8 +148,8 @@ pub struct TestHandle {
 }
 
 impl Handle for TestHandle {
-    fn get_tip(&self) -> Result<(Height, BlockHeader, Uint256), handle::Error> {
-        Ok(self.tip)
+    fn get_tip(&self) -> Result<Tip, handle::Error> {
+        Ok(self.tip.into())
     }
 
     fn get_block(&self, _hash: &BlockHash) -> Result<Option<(Height, BlockHeader)>, handle::Error> {


### PR DESCRIPTION
This is an API change proposal that helps to write more ergonomic Rust IMHO, such as

```rust
if let Ok(Tip{height, ..}) = self.handler.get_tip() {
    let mut resp = json_utils::init_payload();
    let height: i64 = height.to_be().try_into().unwrap();
    json_utils::add_number(&mut resp, "headercount", height);
    json_utils::add_number(&mut resp, "blockcount", height);
    json_utils::add_bool(&mut resp, "ibd", false);
}
```

I leave this as ready but if there is an ack on the change proposal we can support other models in others PR?

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>