### PR TITLE
deps: migrate from lazy_static to one_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,6 @@ version = "0.4.0"
 dependencies = [
  "crossbeam-channel",
  "fastrand",
- "lazy_static",
  "libc",
  "log",
  "nakamoto-net",
@@ -450,9 +449,9 @@ dependencies = [
  "chrono",
  "colored",
  "fastrand",
- "lazy_static",
  "log",
  "nakamoto-common",
+ "once_cell",
  "quickcheck",
 ]
 
@@ -508,6 +507,12 @@ name = "numtoa"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"

--- a/net/poll/Cargo.toml
+++ b/net/poll/Cargo.toml
@@ -17,7 +17,6 @@ libc = { version = "0.2" }
 log = { version = "0.4" }
 
 [dev-dependencies]
-lazy_static = "1.4"
 fastrand = "1.3.5"
 quickcheck = { version = "1", default-features = false }
 quickcheck_macros = "1"

--- a/net/poll/src/fallible.rs
+++ b/net/poll/src/fallible.rs
@@ -1,8 +1,6 @@
 use std::sync::Mutex;
 
-lazy_static! {
-    pub(super) static ref FALLIBLE: Mutex<Option<f64>> = Mutex::new(None);
-}
+pub(super) static FALLIBLE: Mutex<Option<f64>> = Mutex::new(None);
 
 pub(crate) struct FailGuard {}
 

--- a/net/poll/src/lib.rs
+++ b/net/poll/src/lib.rs
@@ -37,10 +37,6 @@ pub use reactor::{Reactor, Waker};
 #[cfg(test)]
 mod fallible;
 
-#[cfg(test)]
-#[macro_use]
-extern crate lazy_static;
-
 /// Makes a function randomly fail with the given error.
 #[macro_export]
 macro_rules! fallible {

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -11,9 +11,9 @@ license = "MIT"
 
 [dependencies]
 nakamoto-common = { version = "0.4.0", path = "../common" }
-lazy_static = "1.4"
 log = { version = "0.4", features = ["std"] }
 chrono = { version = "0.4", features = ["std"], default-features = false }
+once_cell = "1.17.1"
 fastrand = "1.3.5"
 colored = "1.9"
 quickcheck = { version = "1", default_features = false }

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -5,39 +5,35 @@ use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
+use once_cell::sync::Lazy;
+
 use nakamoto_common::bitcoin;
 use nakamoto_common::bitcoin::blockdata::constants;
 use nakamoto_common::bitcoin::consensus::encode::Decodable;
-
-use lazy_static::*;
 
 use nakamoto_common::block::BlockHeader;
 use nakamoto_common::nonempty::NonEmpty;
 
 pub use fastrand;
 
-lazy_static! {
-    pub static ref BITCOIN_HEADERS: NonEmpty<BlockHeader> = {
-        let genesis = constants::genesis_block(bitcoin::Network::Bitcoin).header;
-        let mut f = File::open(&*self::headers::PATH).unwrap();
-        let mut buf = [0; 80];
-        let mut headers = NonEmpty::new(genesis);
+pub static BITCOIN_HEADERS: Lazy<NonEmpty<BlockHeader>> = Lazy::new(|| {
+    let genesis = constants::genesis_block(bitcoin::Network::Bitcoin).header;
+    let mut f = File::open(&*self::headers::PATH).unwrap();
+    let mut buf = [0; 80];
+    let mut headers = NonEmpty::new(genesis);
 
-        while f.read_exact(&mut buf).is_ok() {
-            let header = BlockHeader::consensus_decode(&mut buf.as_slice()).unwrap();
-            headers.push(header);
-        }
-        headers
-    };
-}
+    while f.read_exact(&mut buf).is_ok() {
+        let header = BlockHeader::consensus_decode(&mut buf.as_slice()).unwrap();
+        headers.push(header);
+    }
+    headers
+});
 
 pub mod headers {
     use super::*;
 
-    lazy_static! {
-        pub static ref PATH: PathBuf =
-            Path::new(env!("CARGO_MANIFEST_DIR")).join("data/headers.bin");
-    }
+    pub static PATH: Lazy<PathBuf> =
+        Lazy::new(|| Path::new(env!("CARGO_MANIFEST_DIR")).join("data/headers.bin"));
 }
 
 pub mod logger {


### PR DESCRIPTION
This is a clean-up of the dependencies that migrate from the lazy_static lib to one_cell.

Fixes https://github.com/cloudhead/nakamoto/issues/104