### PR TITLE
fix: remove the assertion

### DIFF
--- a/net/poll/src/reactor.rs
+++ b/net/poll/src/reactor.rs
@@ -244,9 +244,12 @@ impl<Id: PeerId> nakamoto_net::Reactor<Id> for Reactor<net::TcpStream, Id> {
                                 }
                                 popol::Waker::reset(ev.source).ok();
 
-                                // Nb. This assert has triggered once, but I wasn't available
-                                // to reproduce it.
-                                debug_assert!(!commands.is_empty());
+                                // Nb. This should not happen, but it has been reported
+                                // a few times. So we try to log a warning message and
+                                // see how often this occurs.
+                                if commands.is_empty() {
+                                    log::warn!(target: "poll", "waken up by waker received without commands");
+                                }
 
                                 for cmd in commands.try_iter() {
                                     service.command_received(cmd);


### PR DESCRIPTION
It is not clear to me when this happens, but from how the sync function is written there any reason to assert and fails.

Also, while start a new negotiation with a new peer, looks like pretty common get a peer with a different height that maybe is the wrong one?

The crash that I see on my system is

```
thread '<unnamed>' panicked at 'assertion failed: filter_height <= block_height', /home/vincent/.cargo/git/checkouts/nakamoto-90f2d5c288bae2ec/17bbdab/p2p/src/fsm/cbfmgr.rs:853:9
stack backtrace:
   0: rust_begin_unwind
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/std/src/panicking.rs:577:5
   1: core::panicking::panic_fmt
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/core/src/panicking.rs:67:14
   2: core::panicking::panic
             at /rustc/0599b6b931816ab46ab79072189075f543931cbd/library/core/src/panicking.rs:117:5
   3: nakamoto_p2p::fsm::cbfmgr::FilterManager<F,U,C>::sync
             at /home/vincent/.cargo/git/checkouts/nakamoto-90f2d5c288bae2ec/17bbdab/p2p/src/fsm/cbfmgr.rs:853:9
   4: nakamoto_p2p::fsm::cbfmgr::FilterManager<F,U,C>::idle
             at /home/vincent/.cargo/git/checkouts/nakamoto-90f2d5c288bae2ec/17bbdab/p2p/src/fsm/cbfmgr.rs:900:13
   5: nakamoto_p2p::fsm::cbfmgr::FilterManager<F,U,C>::initialize
             at /home/vincent/.cargo/git/checkouts/nakamoto-90f2d5c288bae2ec/17bbdab/p2p/src/fsm/cbfmgr.rs:329:9
   6: <nakamoto_p2p::fsm::StateMachine<T,F,P,C> as nakamoto_net::StateMachine>::initialize
             at /home/vincent/.cargo/git/checkouts/nakamoto-90f2d5c288bae2ec/17bbdab/p2p/src/fsm.rs:782:9
   7: <nakamoto_client::service::Service<T,F,P,C> as nakamoto_net::StateMachine>::initialize
             at /home/vincent/.cargo/git/checkouts/nakamoto-90f2d5c288bae2ec/17bbdab/client/src/service.rs:86:9
   8: <nakamoto_net_poll::reactor::Reactor<std::net::tcp::TcpStream,Id> as nakamoto_net::Reactor<Id>>::run
             at /home/vincent/.cargo/git/checkouts/nakamoto-90f2d5c288bae2ec/17bbdab/net/poll/src/reactor.rs:156:9
   9: nakamoto_client::client::ClientRunner<R>::run
             at /home/vincent/.cargo/git/checkouts/nakamoto-90f2d5c288bae2ec/17bbdab/client/src/client.rs:183:9
  10: nakamoto_client::client::Client<R>::run
             at /home/vincent/.cargo/git/checkouts/nakamoto-90f2d5c288bae2ec/17bbdab/client/src/client.rs:402:9
  11: satoshi_nakamoto::Nakamoto::new::{{closure}}
             at /home/vincent/Github/coffee/satoshi/satoshi-nakamoto/src/lib.rs:41:45
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
2023-04-06T16:54:52.509Z DEBUG   plugin-satoshi_plugin: Err(PluginError { code: -1, msg: \"command channel disconnected\", data: None })
```

Fixes https://github.com/cloudhead/nakamoto/issues/137