### PR TITLE
client: add `get_submitted_tx` method to get the transaction that we submitted

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -22,6 +22,7 @@ use nakamoto_common::bitcoin::network::constants::ServiceFlags;
 use nakamoto_common::bitcoin::network::message::NetworkMessage;
 use nakamoto_common::bitcoin::network::Address;
 use nakamoto_common::bitcoin::util::uint::Uint256;
+use nakamoto_common::bitcoin::Txid;
 use nakamoto_common::block::store::{Genesis as _, Store as _};
 use nakamoto_common::block::time::{AdjustedTime, RefClock};
 use nakamoto_common::block::tree::{self, BlockReader, ImportResult};
@@ -641,6 +642,12 @@ impl<W: Waker> handle::Handle for Handle<W> {
         self.command(Command::SubmitTransaction(tx, transmit))?;
 
         receive.recv()?.map_err(handle::Error::Command)
+    }
+
+    fn get_submitted_transaction(&self, txid: &Txid) -> Result<Option<Transaction>, handle::Error> {
+        let (transmit, receive) = chan::bounded::<Option<Transaction>>(1);
+        self.command(Command::GetSubmittedTransaction(txid.to_owned(), transmit))?;
+        Ok(receive.recv()?)
     }
 
     fn wait<F, T>(&self, f: F) -> Result<T, handle::Error>

--- a/client/src/handle.rs
+++ b/client/src/handle.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use nakamoto_common::bitcoin::network::constants::ServiceFlags;
 use nakamoto_common::bitcoin::network::Address;
 use nakamoto_common::bitcoin::util::uint::Uint256;
-use nakamoto_common::bitcoin::Script;
+use nakamoto_common::bitcoin::{Script, Txid};
 
 use nakamoto_common::bitcoin::network::message::NetworkMessage;
 use nakamoto_common::block::filter::BlockFilter;
@@ -151,6 +151,8 @@ pub trait Handle: Sized + Send + Sync + Clone {
     ///
     /// Returns the peer(s) the transaction was announced to, or an error if no peers were found.
     fn submit_transaction(&self, tx: Transaction) -> Result<NonEmpty<net::SocketAddr>, Error>;
+    /// Return a transaction that was propagated by the client.
+    fn get_submitted_transaction(&self, txid: &Txid) -> Result<Option<Transaction>, Error>;
     /// Import block headers into the node.
     /// This may cause the node to broadcast header or inventory messages to its peers.
     fn import_headers(

--- a/client/src/tests/mock.rs
+++ b/client/src/tests/mock.rs
@@ -10,6 +10,7 @@ use nakamoto_common::bitcoin::network::constants::ServiceFlags;
 use nakamoto_common::bitcoin::network::message::{NetworkMessage, RawNetworkMessage};
 use nakamoto_common::bitcoin::network::Address;
 use nakamoto_common::bitcoin::util::uint::Uint256;
+use nakamoto_common::bitcoin::Txid;
 use nakamoto_common::block::filter::FilterHeader;
 use nakamoto_common::block::store::Genesis as _;
 use nakamoto_common::block::time::{AdjustedTime, LocalTime};
@@ -156,6 +157,13 @@ impl Handle for TestHandle {
     }
 
     fn get_block_by_height(&self, _height: Height) -> Result<Option<BlockHeader>, handle::Error> {
+        unimplemented!()
+    }
+
+    fn get_submitted_transaction(
+        &self,
+        _txid: &Txid,
+    ) -> Result<Option<Transaction>, handle::Error> {
         unimplemented!()
     }
 

--- a/p2p/src/fsm/invmgr.rs
+++ b/p2p/src/fsm/invmgr.rs
@@ -282,6 +282,11 @@ impl<U: Wire<Event> + SetTimer, C: Clock> InventoryManager<U, C> {
         }
     }
 
+    /// Lookup a submitted transaction in the local mempool.
+    pub fn get_submitted_tx(&mut self, txid: &Txid) -> Option<Transaction> {
+        self.mempool.values().find(|tx| tx.txid() == *txid).cloned()
+    }
+
     /// Called when we receive a tick.
     pub fn received_wake<T: BlockReader>(&mut self, tree: &T) {
         let now = self.clock.local_time();


### PR DESCRIPTION
There are use cases with lite clients where it
is necessary to retrieve a submitted transaction by `txid`.