### PR TITLE
feat: add the possibility to query the fee estimation by block

### DIFF
--- a/client/src/handle.rs
+++ b/client/src/handle.rs
@@ -16,6 +16,7 @@ use nakamoto_common::block::filter::BlockFilter;
 use nakamoto_common::block::tree::{BlockReader, ImportResult};
 use nakamoto_common::block::{self, Block, BlockHash, BlockHeader, Height, Transaction};
 use nakamoto_common::nonempty::NonEmpty;
+use nakamoto_p2p::fsm::fees::FeeEstimate;
 use nakamoto_p2p::fsm::Link;
 use nakamoto_p2p::fsm::{self, Command, CommandError, GetFiltersError, Peer};
 
@@ -172,4 +173,6 @@ pub trait Handle: Sized + Send + Sync + Clone {
     fn wait_for_height(&self, h: Height) -> Result<BlockHash, Error>;
     /// Shutdown the node process.
     fn shutdown(self) -> Result<(), Error>;
+    /// Get if exist the fee estimation at the requested height
+    fn estimate_feerate(&self, block: Height) -> Result<Option<FeeEstimate>, Error>;
 }

--- a/client/src/tests/mock.rs
+++ b/client/src/tests/mock.rs
@@ -159,6 +159,13 @@ impl Handle for TestHandle {
         unimplemented!()
     }
 
+    fn estimate_feerate(
+        &self,
+        _block: Height,
+    ) -> Result<Option<fsm::fees::FeeEstimate>, handle::Error> {
+        unimplemented!()
+    }
+
     fn request_block(&self, hash: &BlockHash) -> Result<(), handle::Error> {
         self.command(Command::RequestBlock(*hash))?;
 

--- a/p2p/src/fsm.rs
+++ b/p2p/src/fsm.rs
@@ -282,6 +282,10 @@ pub enum Command {
         Transaction,
         chan::Sender<Result<NonEmpty<PeerId>, CommandError>>,
     ),
+    /// estimate fee by a given height
+    // FIXME: this is not true, this is giving the fee that we know
+    // for a block height, so we should make a better estimation?
+    EstimateFee(Height),
 }
 
 impl fmt::Debug for Command {
@@ -307,6 +311,7 @@ impl fmt::Debug for Command {
             Self::ImportHeaders(_headers, _) => write!(f, "ImportHeaders(..)"),
             Self::ImportAddresses(addrs) => write!(f, "ImportAddresses({:?})", addrs),
             Self::SubmitTransaction(tx, _) => write!(f, "SubmitTransaction({:?})", tx),
+            Self::EstimateFee(block) => write!(f, "EstimateFee({block})"),
         }
     }
 }
@@ -761,6 +766,9 @@ impl<T: BlockTree, F: Filters, P: peer::Store, C: AdjustedClock<PeerId>> StateMa
             }
             Command::Watch { watch } => {
                 self.cbfmgr.watch(watch);
+            }
+            Command::EstimateFee(block) => {
+                self.invmgr.get_fee_estimation(block);
             }
         }
     }

--- a/p2p/src/fsm/invmgr.rs
+++ b/p2p/src/fsm/invmgr.rs
@@ -95,6 +95,13 @@ pub enum Event {
         /// Peer who timed out.
         peer: PeerId,
     },
+    /// Fee Estimation by block height
+    FeeEstimation {
+        /// the block height where the fee estimation was requested
+        block: Height,
+        /// the fee estimated
+        fee: Option<FeeEstimate>,
+    },
 }
 
 impl std::fmt::Display for Event {
@@ -128,6 +135,9 @@ impl std::fmt::Display for Event {
                 write!(fmt, "Transaction {} was reverted", transaction.txid(),)
             }
             Event::TimedOut { peer } => write!(fmt, "Peer {} timed out", peer),
+            Event::FeeEstimation { block, fee } => {
+                write!(fmt, "Fee Estimation {:?} for block at height {block}", fee)
+            }
         }
     }
 }
@@ -187,6 +197,9 @@ pub struct InventoryManager<U, C> {
 
     /// Transaction fee estimator.
     estimator: FeeEstimator,
+    /// Used to track the fee by block, in case the client
+    /// will ask for a fee estimation
+    fees_by_block: BTreeMap<Height, FeeEstimate>,
 
     /// Transaction mempool. Stores unconfirmed transactions sent to the network.
     pub mempool: BTreeMap<Wtxid, Transaction>,
@@ -208,6 +221,7 @@ impl<U: Wire<Event> + SetTimer, C: Clock> InventoryManager<U, C> {
             peers: AddressBook::new(rng.clone()),
             mempool: BTreeMap::new(),
             estimator: FeeEstimator::default(),
+            fees_by_block: BTreeMap::new(),
             confirmed: HashMap::with_hasher(rng.clone().into()),
             remaining: HashMap::with_hasher(rng.clone().into()),
             received: HashMap::with_hasher(rng.clone().into()),
@@ -268,6 +282,7 @@ impl<U: Wire<Event> + SetTimer, C: Clock> InventoryManager<U, C> {
     /// Called when a block is reverted.
     pub fn block_reverted(&mut self, height: Height) -> Vec<Transaction> {
         self.estimator.rollback(height - 1);
+        self.fees_by_block.remove(&height);
 
         if let Some(transactions) = self.confirmed.remove(&height) {
             for tx in transactions.iter().cloned() {
@@ -509,7 +524,9 @@ impl<U: Wire<Event> + SetTimer, C: Clock> InventoryManager<U, C> {
             }
             // Process block through fee estimator.
             let fees = self.estimator.process(block.clone(), height);
-
+            if let Some(val) = &fees {
+                self.fees_by_block.insert(height, val.clone());
+            }
             self.upstream.event(Event::BlockProcessed {
                 block,
                 height,
@@ -517,6 +534,14 @@ impl<U: Wire<Event> + SetTimer, C: Clock> InventoryManager<U, C> {
             });
         }
         confirmed
+    }
+
+    pub fn get_fee_estimation(&self, block: Height) {
+        let estimted_fee = self.fees_by_block.get(&block);
+        self.upstream.event(Event::FeeEstimation {
+            block,
+            fee: estimted_fee.cloned(),
+        });
     }
 
     /// Announce inventories to all matching peers. Retries if necessary.


### PR DESCRIPTION
See commit for details

This is the result on my core lightning node

```
2023-04-07T18:49:18.227Z DEBUG   plugin-satoshi_plugin: fee estimated for block height 2427627 is Some(FeeEstimate { low: 1, median: 1, high: 125 })
2023-04-07T18:49:18.227Z DEBUG   plugin-satoshi_plugin: Ok(Object {\"delayed_to_us\": Number(1), \"htlc_resolution\": Number(1), \"max_acceptable\": Number(1), \"min_acceptable\": Number(1), \"mutual_close\": Number(1), \"opening\": Number(1), \"penalty\": Number(1), \"unilateral_close\": Number(1)})
2023-04-07T18:49:18.227Z DEBUG   lightningd: ... polled feerate estimate for opening (1) smoothed to 142 (alpha=0.44)
2023-04-07T18:49:18.227Z DEBUG   lightningd: ... feerate estimate for opening hit floor 253
2023-04-07T18:49:18.227Z DEBUG   lightningd: ... polled feerate estimate for mutual_close (1) smoothed to 142 (alpha=0.44)
2023-04-07T18:49:18.227Z DEBUG   lightningd: ... feerate estimate for mutual_close hit floor 253
2023-04-07T18:49:18.227Z DEBUG   lightningd: ... polled feerate estimate for unilateral_close (1) smoothed to 142 (alpha=0.44)
2023-04-07T18:49:18.227Z DEBUG   lightningd: ... feerate estimate for unilateral_close hit floor 253
2023-04-07T18:49:18.227Z DEBUG   lightningd: ... polled feerate estimate for delayed_to_us (1) smoothed to 142 (alpha=0.44)
2023-04-07T18:49:18.227Z DEBUG   lightningd: ... feerate estimate for delayed_to_us hit floor 253
2023-04-07T18:49:18.227Z DEBUG   lightningd: ... polled feerate estimate for htlc_resolution (1) smoothed to 142 (alpha=0.44)
2023-04-07T18:49:18.227Z DEBUG   lightningd: ... feerate estimate for htlc_resolution hit floor 253
2023-04-07T18:49:18.227Z DEBUG   lightningd: ... polled feerate estimate for penalty (1) smoothed to 142 (alpha=0.44)
2023-04-07T18:49:18.227Z DEBUG   lightningd: ... feerate estimate for penalty hit floor 253
2023-04-07T18:49:18.227Z DEBUG   lightningd: ... polled feerate estimate for min_acceptable (1) smoothed to 142 (alpha=0.44)
2023-04-07T18:49:18.227Z DEBUG   lightningd: ... feerate estimate for min_acceptable hit floor 253
2023-04-07T18:49:18.227Z DEBUG   lightningd: ... polled feerate estimate for max_acceptable (1) smoothed to 142 (alpha=0.44)
2023-04-07T18:49:18.227Z DEBUG   lightningd: ... feerate estimate for max_acceptable hit floor 253

```